### PR TITLE
Fix JAX version mismatch in Lab 1.3 notebook

### DIFF
--- a/course_1/gdm_lab_1_3_compare_n_gram_models_and_transformer_language_models.ipynb
+++ b/course_1/gdm_lab_1_3_compare_n_gram_models_and_transformer_language_models.ipynb
@@ -173,7 +173,7 @@
       "outputs": [],
       "source": [
         "%%capture\n",
-        "!pip install orbax-checkpoint==0.11.21 jax[cuda12]==0.6.2\n",
+        "!pip install orbax-checkpoint==0.11.21 jax[cuda12]==0.7.2\n",
         "!pip install \"git+https://github.com/google-deepmind/ai-foundations.git@main\"\n",
         "\n",
         "# Packages used.\n",


### PR DESCRIPTION
## Summary

- Update `jax[cuda12]` from `0.6.2` to `0.7.2` in the Lab 1.3 notebook install cell to match the version specified in `pyproject.toml`

## Problem

The notebook pinned `jax[cuda12]==0.6.2` but `pyproject.toml` requires `jax==0.7.2`. This version mismatch caused errors when loading the Gemma-1B model in Google Colab:

- `TypeError: 'StepMetadata' object is not iterable` (Issue #13)
- `RuntimeError: Unable to initialize backend 'cuda'` (Issue #12)

## Fix

Changed the install line from:
```python
!pip install orbax-checkpoint==0.11.21 jax[cuda12]==0.6.2
```

To:
```python
!pip install orbax-checkpoint==0.11.21 jax[cuda12]==0.7.2
```

## Test plan

- [x] Tested in Google Colab with T4 GPU runtime
- [x] Verified Gemma-1B model loads successfully
- [x] Verified notebook runs end-to-end without errors

Fixes #12
Fixes #13