### PR TITLE
Fix swapped correct/incorrect feedback in check_loralab_answer.py

### DIFF
--- a/ai_foundations/feedback/course_5/lora/check_loralab_answer.py
+++ b/ai_foundations/feedback/course_5/lora/check_loralab_answer.py
@@ -55,18 +55,18 @@ def check_loralab_answer(
   elif ((jnp.abs(answer - answer_without_bias) < tolerance)
         or (jnp.abs(answer - answer_with_bias) < tolerance)):
     print(
+        "✅ Nice! Your answer looks correct.\n"
+        "If you consider bias weights, the answer is"
+        f" {jnp.round(answer_with_bias, decimals=5)}.\n"
+        "If you don't consider bias weights, the answer is"
+        f" {jnp.round(answer_without_bias, decimals=5)}."
+    )
+  else:
+    print(
         "❌ Your answer is not correct.\n"
         f"Matrices A and B each have {rank} x {num_units}"
         f" = {rank * num_units} trainable parameters.\n"
         f"The full weight matrix has {num_units} x {num_units}"
         f" = {num_units * num_units} parameters.\n"
         f"There are {num_units} bias weights."
-    )
-  else:
-    print(
-        "✅ Nice! Your answer looks correct.\n"
-        "If you consider bias weights, the answer is"
-        f" {jnp.round(answer_with_bias, decimals=5)}.\n"
-        "If you don't consider bias weights, the answer is"
-        f" {jnp.round(answer_without_bias, decimals=5)}."
     )


### PR DESCRIPTION
## Summary
- Fixes #15: The `elif` and `else` branches in `check_loralab_answer()` had their feedback messages swapped — correct answers received failure messages and wrong answers received success messages.
- Swapped the print blocks so the correct-answer branch prints the success message and the wrong-answer branch prints the failure message.

## Test plan
- [ ] Call `check_loralab_answer(2 * 8 / 512)` — should now print the success message
- [ ] Call `check_loralab_answer(0.999)` — should now print the failure message with hints
- [ ] Call `check_loralab_answer(1.5)` — should still print the out-of-range message