### PR TITLE
Update Course 5 notebooks to use current Kaggle API token auth

### DIFF
--- a/course_5/gdm_lab_5_4_full_parameter_fine_tuning_of_gemma.ipynb
+++ b/course_5/gdm_lab_5_4_full_parameter_fine_tuning_of_gemma.ipynb
@@ -1,578 +1,492 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "McySAWvt09wn"
-      },
-      "source": [
-        "> <p><small><small>This Notebook is made available subject to the licence and terms set out in the <a href = \"http://www.github.com/google-deepmind/ai-foundations\">AI Research Foundations Github README file</a>."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "bg_nGpxOxaPv"
-      },
-      "source": [
-        "<img src=\"https://storage.googleapis.com/dm-educational/assets/ai_foundations/GDM-Labs-banner-image-C5-white-bg.png\">"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "6bW1AyB_f7eo"
-      },
-      "source": [
-        "# Lab: Full-Parameter Fine-Tuning of Gemma\n",
-        "\n",
-        "<a href='https://colab.research.google.com/github/google-deepmind/ai-foundations/blob/master/course_5/gdm_lab_5_4_full_parameter_fine_tuning_of_gemma.ipynb' target='_parent'><img src='https://colab.research.google.com/assets/colab-badge.svg' alt='Open In Colab'/></a>\n",
-        "\n",
-        "15 minutes\n",
-        "\n",
-        "Attempt to perform full-parameter fine-tuning of a Gemma model."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "md4FSU7h9dQR"
-      },
-      "source": [
-        "## Overview\n",
-        "\n",
-        "In the previous lab, you fine-tuned a small language model. As you observed, that model was able to often produce reasonable quality answers for flashcards on topics that are in the Africa Galore dataset. However, it generally failed when it was prompted to generate answers for flashcards on topics that are not included in the Africa Galore dataset.\n",
-        "\n",
-        "In this lab, you will attempt to apply the full-parameter fine-tuning technique to the pre-trained Gemma model. Since Gemma has been trained on a lot more data, it will likely be able to generate useful answers to many more questions. However, when you try to apply full-parameter fine-tuning, you will quickly encounter a critical real-world constraint: memory limitations. This lab is designed to demonstrate first-hand why full-parameter fine-tuning can be challenging with large models and why more efficient techniques are needed.\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "g8u6btAn9jc4"
-      },
-      "source": [
-        "### What you will learn\n",
-        "By the end of this lab, you will be able to:\n",
-        "\n",
-        "* Load and interact with a Keras implementation of a pre-trained Gemma model.\n",
-        "* Recognize the practical memory limitations of full-parameter fine-tuning when applied to billion-parameter models."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "qIhcVxx0foVo"
-      },
-      "source": [
-        "### Tasks\n",
-        "\n",
-        "**In this lab, you will**:\n",
-        "* Prepare the flashcard dataset for use with the Gemma tokenizer and Keras.\n",
-        "* Load the pre-trained Gemma model and test its base performance with a few prompts.\n",
-        "* Attempt to perform full-parameter fine-tuning on the model.\n",
-        "* Observe the memory-related errors that prevent the training from succeeding.\n",
-        "\n",
-        " **This lab must be run on a GPU. Choose a T4 GPU.** See the section \"How to use Google Colaboratory (Colab)\" below for instructions on how to do this.\n",
-        "\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "NDWsJUGcf4Ru"
-      },
-      "source": [
-        "## How to use Google Colaboratory (Colab)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "wlNG_jg-39Zj"
-      },
-      "source": [
-        "Google Colaboratory (also known as Google Colab) is a platform that allows you to run Python code in your browser. The code is written in cells that are executed on a remote server.\n",
-        "\n",
-        "To run a cell, hover over a cell, and click the `run` button to its left. The run button is the circle with the triangle (▶). Alternatively, you can also click a cell and use the keyboard combination Ctrl+Return (or ⌘+Return if you are using a Mac).\n",
-        "\n",
-        "To try this out, run the following cell. This should print today's day of the week below it."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "UyTT6C0JhGBs"
-      },
-      "outputs": [],
-      "source": [
-        "from datetime import datetime\n",
-        "print(f\"Today is {datetime.today():%A}.\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "pbtgZxrpjm6j"
-      },
-      "source": [
-        "Note that the order in which you run the cells matters. When you are working through a lab, make sure to always run all cells in order. Otherwise, the code might not work. If you take a break while working on a lab, Colab may disconnect you; in that case, you have to execute all cells again before continuing your work. To make this easier, you can select the cell you are currently working on and then choose __Runtime → Run before__  from the menu above (or use the keyboard combination Ctrl/⌘ + F8). This will re-execute all cells before the current one."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "qLvkcx5pUItk"
-      },
-      "source": [
-        "### Using Colab with a GPU\n",
-        "\n",
-        "Follow these steps to run the activities in this lab on a GPU:\n",
-        "\n",
-        "1.  In the top menu bar, click on **Runtime**.\n",
-        "2.  Select **Change runtime type** from the dropdown menu.\n",
-        "3.  In the pop-up window under **Hardware Accelerator**, select **GPU** (usually listed as `T4 GPU`).\n",
-        "4.  Click **Save**.\n",
-        "\n",
-        "Your Colab session will now restart with GPU access.\n",
-        "\n",
-        "Note that access to GPUs is limited and at times, you may not be able to run this lab on a GPU. All activities will still work but they will run slower and you will have to wait longer for some of the cells to finish running.\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "## Set up a Kaggle account\n",
-        "\n",
-        "To run this notebook, you will have to sign up for [Kaggle](https://www.kaggle.com), a platform that hosts datasets and models for machine learning, and sign the agreement for using the Gemma 3 model. This is required so that you can download the weights of the Gemma model for fine-tuning.\n",
-        "\n",
-        "### Step 1: Create your Kaggle account\n",
-        "\n",
-        "* Go to the Kaggle website: https://www.kaggle.com\n",
-        "\n",
-        "* Click the \"Register\" button in the top-right corner.\n",
-        "\n",
-        "* You can sign up using your Google account (recommended for easy Colab integration) or by entering an email and password.\n",
-        "\n",
-        "* Follow the on-screen prompts to complete your registration and verify your email.\n",
-        "\n",
-        "### Step 2: Sign the Gemma 3 model agreement\n",
-        "\n",
-        "* Make sure you are logged into your new Kaggle account.\n",
-        "\n",
-        "* Go directly to the Gemma 3 model card page: https://www.kaggle.com/models/keras/gemma3/keras/\n",
-        "\n",
-        "* You should see a \"Request Access\" button.\n",
-        "\n",
-        "* Click the button, read through the license agreement, and click \"Accept\" to gain access to the model. You must do this before the API will let you download the model.\n",
-        "\n",
-        "### Step 3: Generate your Kaggle API key\n",
-        "\n",
-        "* From any Kaggle page, click on your profile picture or icon in the top-right corner.\n",
-        "\n",
-        "* Select \"Account\" from the drop-down menu.\n",
-        "\n",
-        "* Scroll down to the \"API\" section.\n",
-        "\n",
-        "* Click the \"Create New API Token\" button.\n",
-        "\n",
-        "* This will immediately download a file named `kaggle.json` to your computer. This file contains your username and your secret API key. Keep it safe.\n",
-        "\n",
-        "### Step 4: Set your API Key in  Colab\n",
-        "\n",
-        "* Click the \"key\" icon 🔑 in the left-hand sidebar.\n",
-        "\n",
-        "* You will see the \"Secrets\" panel.\n",
-        "\n",
-        "* Now, open the kaggle.json file you downloaded on your computer. It's a simple text file and will look like this:\n",
-        "\n",
-        "   ```json\n",
-        "   {\"username\":\"YOUR_KAGGLE_USERNAME\",\"key\":\"YOUR_KAGGLE_API_KEY\"}\n",
-        "   ```\n",
-        "* In the Colab Secrets panel, create two new secrets:\n",
-        "\n",
-        "   1. Name: `KAGGLE_USERNAME`\n",
-        "\n",
-        "      Value: Copy and paste `YOUR_KAGGLE_USERNAME` from your `kaggle.json` file.\n",
-        "\n",
-        "   2. Name: `KAGGLE_KEY`\n",
-        "\n",
-        "      Value: Copy and paste `YOUR_KAGGLE_API_KEY` from your `kaggle.json` file.\n",
-        "\n",
-        "* For both secrets, make sure the \"Notebook access\" toggle is switched on.\n"
-      ],
-      "metadata": {
-        "id": "U0VAvArwlQza"
-      }
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "## Imports\n",
-        "\n",
-        "In this lab, you will use the Keras package for loading a Gemma model, as well as the Pandas package for loading the dataset.\n",
-        "\n",
-        "Run the following cell to import the required packages.\n"
-      ],
-      "metadata": {
-        "id": "MaICqS1MOP8e"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "%%capture\n",
-        "# Install the custom package for this course.\n",
-        "!pip install \"git+https://github.com/google-deepmind/ai-foundations.git@main\"\n",
-        "\n",
-        "import os\n",
-        "\n",
-        "# For loading the Kaggle username and key.\n",
-        "from google.colab import userdata\n",
-        "\n",
-        "# Load the Kaggle username and key.\n",
-        "os.environ[\"KAGGLE_USERNAME\"] = userdata.get(\"KAGGLE_USERNAME\")\n",
-        "os.environ[\"KAGGLE_KEY\"] = userdata.get(\"KAGGLE_KEY\")\n",
-        "\n",
-        "os.environ[\"KERAS_BACKEND\"] = \"jax\" # Set the Keras backend to JAX.\n",
-        "\n",
-        "import keras # For training the model.\n",
-        "import keras_nlp # For loading Gemma 3.\n",
-        "import pandas as pd # For loading the dataset.\n",
-        "from textwrap import fill # For making paragraphs more readable.\n",
-        "# For loading the formatting function from the lab\n",
-        "# \"Format Text for Turn-Based Dialogue.\"\n",
-        "from ai_foundations import formatting\n",
-        "\n",
-        "# Avoid memory fragmentation on JAX backend.\n",
-        "os.environ[\"XLA_PYTHON_CLIENT_MEM_FRACTION\"] = \"0.95\"\n",
-        "keras.utils.set_random_seed(812) # For making the training reproducible."
-      ],
-      "metadata": {
-        "id": "TAQmA4Vl7PTM"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "## Motivation\n",
-        "\n",
-        "As discussed in the previous article, fine-tuning foundation models provides you with an option to leverage the knowledge that comes from pre-training a model on large amounts of data.\n",
-        "\n",
-        "To get a better sense of how a pre-trained model, such as Gemma-1B, differs from the small language model (SLM) you  worked with in the previous lab, consider the comparisons in the following table:\n",
-        "\n",
-        "|  | Gemma-1B | SLM |\n",
-        "|----------|----------|----------|\n",
-        "| Number of parameters | 1,000,000,000 | 523,470 |\n",
-        "| Tokens in vocabulary | 256,000 | 3,086 |\n",
-        "| Tokens in training set | 2,000,000,000,000 | 92,568 |\n",
-        "| Training data | Web documents in 140 languages | Africa Galore dataset |\n",
-        "\n",
-        "As this table shows, the Gemma model contains considerably more parameters (~1 billion versus ~500,000) and has been trained on a dataset that is much larger and much more diverse than the Africa Galore dataset. This combination allows the model to learn and store more information than the small language model. As such, if you fine-tune Gemma-1B to produce answers for a flashcard, it will be able to provide useful answers for a much larger range of topics than the SLM."
-      ],
-      "metadata": {
-        "id": "_DTMWa2RnlY1"
-      }
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "## Data pre-processing\n",
-        "\n",
-        "As with your SLM, you have to make sure that your fine-tuning data uses the  tokenizer and the special delimiter tokens that were used during pre-training. In this course, you are using the format that instruction-tuned Gemma models use (introduced in the lab \"Formatting\" on turn-based formatting) [1]. It uses special tokens to mark the beginning and end of a turn, and indicates the role (`user` or `model`).\n",
-        "\n",
-        "A single training example will be structured as follows:\n",
-        "\n",
-        "------\n",
-        "> `<start_of_turn>`user\n",
-        ">\n",
-        "> What is Jollof rice?`<end_of_turn>`\n",
-        ">\n",
-        "> `<start_of_turn>`model\n",
-        ">\n",
-        "> Category: Food\n",
-        ">\n",
-        "> Jollof rice is a popular and iconic one-pot rice dish that is a staple in many West African countries.`<end_of_turn>`\n",
-        "------\n",
-        "\n",
-        "Run the following cell to load the Africa Galore QA dataset and format each example so that it has this structure."
-      ],
-      "metadata": {
-        "id": "rC4ZM0nap6OV"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "# Load the question-answer dataset.\n",
-        "africa_galore_qa = pd.read_json(\n",
-        "    \"https://storage.googleapis.com/dm-educational/assets/ai_foundations/africa_galore_qa_v2.json\"\n",
-        ")\n",
-        "\n",
-        "questions = []  # List of formatted questions.\n",
-        "answers = []  # List of formatted answers.\n",
-        "\n",
-        "for idx, row in africa_galore_qa.iterrows():\n",
-        "    # Run the format_qa function from the previous lab to format the question\n",
-        "    # and the answer.\n",
-        "    question, answer = formatting.format_qa(row)\n",
-        "    questions.append(question)\n",
-        "    answers.append(answer)\n",
-        "\n",
-        "# Show the first set of inputs and outputs.\n",
-        "print(questions[0])\n",
-        "print(fill(answers[0], replace_whitespace=False))"
-      ],
-      "metadata": {
-        "id": "5Ra4HE2Y_FaT"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "Recall that in the previous lab, you had to perform additional steps for preparing the data. You also had to tokenize each question and each answer and you had to manually replace some tokens in the target with the special `<PAD>` token to exclude it from the loss computation.\n",
-        "\n",
-        "Since fine-tuning a model is a very common task, implementations of models like Gemma often already implement functions that take care of several steps of data preparation as part of a preprocessor.\n",
-        "\n",
-        "In the case of the Keras implementation of the Gemma model, you only need to specify the prompt and what you would like the model to generate. It then automatically constructs tokenized examples that can be used to fine-tune a Gemma language model. In the background, it concatenates the prompts and responses and excludes the tokens in the prompt from the loss computation. This saves you many common steps. Note, however, that it does not automatically add `<start_of_turn>` or `<end_of_turn>` tokens, so you still have to provide these tokens to the model, as you did in the previous cell."
-      ],
-      "metadata": {
-        "id": "Z04UnLYebZlL"
-      }
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "### Preparing data for the Keras model\n",
-        "\n",
-        "The Keras implementation of Gemma expects the fine-tuning data to be structured as a Python dictionary with two specific keys: `prompts` for the prompts (these are the questions in the case of the flashcard generator) and `responses` for the generations that the model should output (the answers in the case of the flashcard generator).\n",
-        "\n",
-        "Run the following cell to initialize this dictionary."
-      ],
-      "metadata": {
-        "id": "s7yrCJJisdee"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "data = {\n",
-        "    \"prompts\": questions,\n",
-        "    \"responses\": answers\n",
-        "}"
-      ],
-      "metadata": {
-        "id": "xspsmEJbpcS9"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "## Loading the Gemma model with Keras\n",
-        "\n",
-        "The following cell loads the pre-trained [Gemma-1B model](https://ai.google.dev/gemma/docs/core/prompt-structure) using Keras [2]. Like your SLM, this model has been trained on the next-word prediction task and it has not been optimized for answering questions. After loading, you can print a summary using the `summary` method to inspect its architecture.\n",
-        "\n",
-        "------\n",
-        "> **💭 Reflection: Memory requirements**\n",
-        ">\n",
-        "> Before running the code, consider the following questions:\n",
-        ">\n",
-        "> * How many parameters do you expect the model to have?\n",
-        "> * If you are using a Colab notebook with a T4 GPU, it will have about 15GB of memory. Will you be able to load the entire model into the memory of your GPU?\n",
-        "> * Would a much larger model, like Gemma-27B, fit on your GPU?\n",
-        ">\n",
-        "------\n",
-        "\n",
-        "Run the following cell to load the model and initialize the preprocessor.\n",
-        "\n",
-        "\n"
-      ],
-      "metadata": {
-        "id": "rQfwovolu46v"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "# Load the Gemma3-1B Keras model.\n",
-        "model = keras_nlp.models.Gemma3CausalLM.from_preset(\"gemma3_1b\")\n",
-        "model.summary()\n",
-        "\n",
-        "# Set the maximum sequence length of the model for padding and batching.\n",
-        "model.preprocessor.sequence_length = 400"
-      ],
-      "metadata": {
-        "id": "ZKvAc-Hx7QAa"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "#### Understanding Gemma's Memory Footprint"
-      ],
-      "metadata": {
-        "id": "Hhtv392yt11v"
-      }
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "The Gemma 1B model has approximately 1.3 billion parameters (1B for the main transformer blocks and 300M for the token embeddings). A model of this size typically requires around 4GB of memory, so it fits on a T4 GPU with 15GB of memory. However, a 27B model, that is a model with around 27 billion parameters would require roughly 100 GB of memory (27 $\\times$ ~3.7 GB), which exceeds the capacity of a single T4 GPU multiple times.\n",
-        "\n"
-      ],
-      "metadata": {
-        "id": "rzi9osL_w1F3"
-      }
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "## Prompting the base model\n",
-        "\n",
-        "Before you fine-tune the model, observe how the pre-trained base model performs when you prompt it with a question.\n"
-      ],
-      "metadata": {
-        "id": "MrLhNUOKxkZg"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "prompt = \"What is Jollof rice?\"\n",
-        "response = model.generate(prompt, max_length=200)\n",
-        "print(fill(response, replace_whitespace=False))"
-      ],
-      "metadata": {
-        "id": "C9Lan88tx73I"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "### What did you observe?\n",
-        "\n",
-        "For a prompt such as \"What is Jollof rice?\", you likely observed that the model's response contains repetitions, is not concise and may go off topic. Furthermore, it does not output the response in the desired flashcard format.\n",
-        "\n",
-        "These shortcomings are expected. Recall that this model has been trained on large amounts of text data to predict the next token but, unlike instruction-tuned models, it has not been optimized to respond to user queries. Furthermore, its pre-training does not contain any information about the format for the flashcard generator.\n",
-        "\n",
-        "By fine-tuning a model you can address both of these issues. The model will learn to produce more concise responses to questions and learn to follow the flashcard format, since both of these qualities are demonstrated in the training examples of the Africa Galore QA dataset."
-      ],
-      "metadata": {
-        "id": "endeHMkAyERI"
-      }
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "## Attempting full-parameter fine-tuning\n",
-        "\n",
-        "Fine-tuning requires significantly more memory than using a model for inference. For each parameter, the training process must store not only the current value of the parameter itself, but also the gradient and other variables used by the optimizer. Because of this, training a model requires several times more memory than using a model for generations."
-      ],
-      "metadata": {
-        "id": "rt1-4R0iyVXX"
-      }
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "For this step, run the following code to fine-tune the Gemma-1B model using the same full-parameter approach that you used for fine-tuning your SLM. The code below updates all of Gemma's parameters.\n",
-        "\n",
-        "Note that if you encounter an error while running fine-tuning, continue reading on for guidance."
-      ],
-      "metadata": {
-        "id": "bTLtTY6Uy95J"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "model.fit(data, epochs=1, batch_size=32, verbose=1)"
-      ],
-      "metadata": {
-        "id": "r2A8rJJt-3TG"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "### What did you observe?\n",
-        "\n",
-        "\n",
-        "When running the cell above, you should observe an \"out of memory\" (OOM) error. This occurred because the optimizer attempted to allocate more memory than is available on a T4 GPU when trying to fine-tune all 1.3 billion parameters of the Gemma-1B model. When this happens, the entire Colab session will crash and you have to re-run all of the code again.\n",
-        "\n",
-        "This is an intentional step that highlights that you may be able to load models with more than 1B parameters and perform inference on a T4 GPU with 15GB, as you did earlier in this lab, but this does not mean that you can also fine-tune all parameters of such a model. As you will learn in more detail in future courses, any form of model training, including fine-tuning, requires significantly more memory, since you also have to store gradients and information for the optimizer in the GPU's memory.\n",
-        "\n",
-        "\n",
-        "\n"
-      ],
-      "metadata": {
-        "id": "jZoyh3jwzp4A"
-      }
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "## Summary\n",
-        "\n",
-        "In this lab, you experimented with the pre-trained Gemma-1B model. You attempted to adapt it to a new task using full-parameter fine-tuning and discovered that this method is often impractical for large models due to prohibitive memory requirements.\n",
-        "\n",
-        "To solve this, you need a more sophisticated approach. The upcoming labs will introduce you to the concept of parameter-efficient fine-tuning (PEFT) and a technique called LoRA, which will allow you to fine-tune large models, such as Gemma, with limited GPU memory."
-      ],
-      "metadata": {
-        "id": "tuWmXJiQUaiS"
-      }
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "## References\n",
-        "\n",
-        "[1] Google AI - Gemma Prompt Structure\n",
-        "Google AI. 2025. Gemma formatting and system instructions. Retrieved from https://ai.google.dev/gemma/docs/core/prompt-structure\n",
-        "\n",
-        "[2] Keras Hub - Gemma3CausalLM\n",
-        "Keras. 2025. Gemma3CausalLM model. Retrieved from https://keras.io/keras_hub/api/models/gemma3/gemma3_causal_lm/\n",
-        "\n",
-        "\n",
-        "\n",
-        "\n",
-        "\n"
-      ],
-      "metadata": {
-        "id": "_1fqgdQSv-Gv"
-      }
-    }
-  ],
-  "metadata": {
-    "colab": {
-      "collapsed_sections": [
-        "NDWsJUGcf4Ru"
-      ],
-      "provenance": [],
-      "gpuType": "T4"
-    },
-    "kernelspec": {
-      "display_name": "Python 3",
-      "name": "python3"
-    },
-    "language_info": {
-      "name": "python"
-    },
-    "accelerator": "GPU"
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "McySAWvt09wn"
+   },
+   "source": [
+    "> <p><small><small>This Notebook is made available subject to the licence and terms set out in the <a href = \"http://www.github.com/google-deepmind/ai-foundations\">AI Research Foundations Github README file</a>."
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 0
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "bg_nGpxOxaPv"
+   },
+   "source": [
+    "<img src=\"https://storage.googleapis.com/dm-educational/assets/ai_foundations/GDM-Labs-banner-image-C5-white-bg.png\">"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "6bW1AyB_f7eo"
+   },
+   "source": [
+    "# Lab: Full-Parameter Fine-Tuning of Gemma\n",
+    "\n",
+    "<a href='https://colab.research.google.com/github/google-deepmind/ai-foundations/blob/master/course_5/gdm_lab_5_4_full_parameter_fine_tuning_of_gemma.ipynb' target='_parent'><img src='https://colab.research.google.com/assets/colab-badge.svg' alt='Open In Colab'/></a>\n",
+    "\n",
+    "15 minutes\n",
+    "\n",
+    "Attempt to perform full-parameter fine-tuning of a Gemma model."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "md4FSU7h9dQR"
+   },
+   "source": [
+    "## Overview\n",
+    "\n",
+    "In the previous lab, you fine-tuned a small language model. As you observed, that model was able to often produce reasonable quality answers for flashcards on topics that are in the Africa Galore dataset. However, it generally failed when it was prompted to generate answers for flashcards on topics that are not included in the Africa Galore dataset.\n",
+    "\n",
+    "In this lab, you will attempt to apply the full-parameter fine-tuning technique to the pre-trained Gemma model. Since Gemma has been trained on a lot more data, it will likely be able to generate useful answers to many more questions. However, when you try to apply full-parameter fine-tuning, you will quickly encounter a critical real-world constraint: memory limitations. This lab is designed to demonstrate first-hand why full-parameter fine-tuning can be challenging with large models and why more efficient techniques are needed.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "g8u6btAn9jc4"
+   },
+   "source": [
+    "### What you will learn\n",
+    "By the end of this lab, you will be able to:\n",
+    "\n",
+    "* Load and interact with a Keras implementation of a pre-trained Gemma model.\n",
+    "* Recognize the practical memory limitations of full-parameter fine-tuning when applied to billion-parameter models."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "qIhcVxx0foVo"
+   },
+   "source": [
+    "### Tasks\n",
+    "\n",
+    "**In this lab, you will**:\n",
+    "* Prepare the flashcard dataset for use with the Gemma tokenizer and Keras.\n",
+    "* Load the pre-trained Gemma model and test its base performance with a few prompts.\n",
+    "* Attempt to perform full-parameter fine-tuning on the model.\n",
+    "* Observe the memory-related errors that prevent the training from succeeding.\n",
+    "\n",
+    " **This lab must be run on a GPU. Choose a T4 GPU.** See the section \"How to use Google Colaboratory (Colab)\" below for instructions on how to do this.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "NDWsJUGcf4Ru"
+   },
+   "source": [
+    "## How to use Google Colaboratory (Colab)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "wlNG_jg-39Zj"
+   },
+   "source": [
+    "Google Colaboratory (also known as Google Colab) is a platform that allows you to run Python code in your browser. The code is written in cells that are executed on a remote server.\n",
+    "\n",
+    "To run a cell, hover over a cell, and click the `run` button to its left. The run button is the circle with the triangle (▶). Alternatively, you can also click a cell and use the keyboard combination Ctrl+Return (or ⌘+Return if you are using a Mac).\n",
+    "\n",
+    "To try this out, run the following cell. This should print today's day of the week below it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "UyTT6C0JhGBs"
+   },
+   "outputs": [],
+   "source": [
+    "from datetime import datetime\n",
+    "print(f\"Today is {datetime.today():%A}.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "pbtgZxrpjm6j"
+   },
+   "source": [
+    "Note that the order in which you run the cells matters. When you are working through a lab, make sure to always run all cells in order. Otherwise, the code might not work. If you take a break while working on a lab, Colab may disconnect you; in that case, you have to execute all cells again before continuing your work. To make this easier, you can select the cell you are currently working on and then choose __Runtime → Run before__  from the menu above (or use the keyboard combination Ctrl/⌘ + F8). This will re-execute all cells before the current one."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "qLvkcx5pUItk"
+   },
+   "source": [
+    "### Using Colab with a GPU\n",
+    "\n",
+    "Follow these steps to run the activities in this lab on a GPU:\n",
+    "\n",
+    "1.  In the top menu bar, click on **Runtime**.\n",
+    "2.  Select **Change runtime type** from the dropdown menu.\n",
+    "3.  In the pop-up window under **Hardware Accelerator**, select **GPU** (usually listed as `T4 GPU`).\n",
+    "4.  Click **Save**.\n",
+    "\n",
+    "Your Colab session will now restart with GPU access.\n",
+    "\n",
+    "Note that access to GPUs is limited and at times, you may not be able to run this lab on a GPU. All activities will still work but they will run slower and you will have to wait longer for some of the cells to finish running.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "source": "## Set up a Kaggle account\n\nTo run this notebook, you will have to sign up for [Kaggle](https://www.kaggle.com), a platform that hosts datasets and models for machine learning, and sign the agreement for using the Gemma 3 model. This is required so that you can download the weights of the Gemma model for fine-tuning.\n\n### Step 1: Create your Kaggle account\n\n* Go to the Kaggle website: https://www.kaggle.com\n\n* Click the \"Register\" button in the top-right corner.\n\n* You can sign up using your Google account (recommended for easy Colab integration) or by entering an email and password.\n\n* Follow the on-screen prompts to complete your registration and verify your email.\n\n### Step 2: Sign the Gemma 3 model agreement\n\n* Make sure you are logged into your new Kaggle account.\n\n* Go directly to the Gemma 3 model card page: https://www.kaggle.com/models/keras/gemma3/keras/\n\n* You should see a \"Request Access\" button.\n\n* Click the button, read through the license agreement, and click \"Accept\" to gain access to the model. You must do this before the API will let you download the model.\n\n### Step 3: Generate your Kaggle API token\n\n* From any Kaggle page, click on your profile picture or icon in the top-right corner.\n\n* Select \"Settings\" from the drop-down menu.\n\n* Scroll down to the \"API\" section.\n\n* Click the \"Generate New Token\" button.\n\n* Copy the token value that is displayed.\n\n### Step 4: Set your API token in Colab\n\n* Click the \"key\" icon 🔑 in the left-hand sidebar.\n\n* You will see the \"Secrets\" panel.\n\n* In the Colab Secrets panel, create a new secret:\n\n   * Name: `KAGGLE_API_TOKEN`\n\n   * Value: Paste the token you copied in Step 3.\n\n* Make sure the \"Notebook access\" toggle is switched on.",
+   "metadata": {
+    "id": "U0VAvArwlQza"
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Imports\n",
+    "\n",
+    "In this lab, you will use the Keras package for loading a Gemma model, as well as the Pandas package for loading the dataset.\n",
+    "\n",
+    "Run the following cell to import the required packages.\n"
+   ],
+   "metadata": {
+    "id": "MaICqS1MOP8e"
+   }
+  },
+  {
+   "cell_type": "code",
+   "source": "%%capture\n# Install the custom package for this course.\n!pip install \"git+https://github.com/google-deepmind/ai-foundations.git@main\"\n\nimport os\n\n# For loading the Kaggle API token.\nfrom google.colab import userdata\n\n# Load the Kaggle API token.\nos.environ[\"KAGGLE_API_TOKEN\"] = userdata.get(\"KAGGLE_API_TOKEN\")\n\nos.environ[\"KERAS_BACKEND\"] = \"jax\" # Set the Keras backend to JAX.\n\nimport keras # For training the model.\nimport keras_nlp # For loading Gemma 3.\nimport pandas as pd # For loading the dataset.\nfrom textwrap import fill # For making paragraphs more readable.\n# For loading the formatting function from the lab\n# \"Format Text for Turn-Based Dialogue.\"\nfrom ai_foundations import formatting\n\n# Avoid memory fragmentation on JAX backend.\nos.environ[\"XLA_PYTHON_CLIENT_MEM_FRACTION\"] = \"0.95\"\nkeras.utils.set_random_seed(812) # For making the training reproducible.",
+   "metadata": {
+    "id": "TAQmA4Vl7PTM"
+   },
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Motivation\n",
+    "\n",
+    "As discussed in the previous article, fine-tuning foundation models provides you with an option to leverage the knowledge that comes from pre-training a model on large amounts of data.\n",
+    "\n",
+    "To get a better sense of how a pre-trained model, such as Gemma-1B, differs from the small language model (SLM) you  worked with in the previous lab, consider the comparisons in the following table:\n",
+    "\n",
+    "|  | Gemma-1B | SLM |\n",
+    "|----------|----------|----------|\n",
+    "| Number of parameters | 1,000,000,000 | 523,470 |\n",
+    "| Tokens in vocabulary | 256,000 | 3,086 |\n",
+    "| Tokens in training set | 2,000,000,000,000 | 92,568 |\n",
+    "| Training data | Web documents in 140 languages | Africa Galore dataset |\n",
+    "\n",
+    "As this table shows, the Gemma model contains considerably more parameters (~1 billion versus ~500,000) and has been trained on a dataset that is much larger and much more diverse than the Africa Galore dataset. This combination allows the model to learn and store more information than the small language model. As such, if you fine-tune Gemma-1B to produce answers for a flashcard, it will be able to provide useful answers for a much larger range of topics than the SLM."
+   ],
+   "metadata": {
+    "id": "_DTMWa2RnlY1"
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Data pre-processing\n",
+    "\n",
+    "As with your SLM, you have to make sure that your fine-tuning data uses the  tokenizer and the special delimiter tokens that were used during pre-training. In this course, you are using the format that instruction-tuned Gemma models use (introduced in the lab \"Formatting\" on turn-based formatting) [1]. It uses special tokens to mark the beginning and end of a turn, and indicates the role (`user` or `model`).\n",
+    "\n",
+    "A single training example will be structured as follows:\n",
+    "\n",
+    "------\n",
+    "> `<start_of_turn>`user\n",
+    ">\n",
+    "> What is Jollof rice?`<end_of_turn>`\n",
+    ">\n",
+    "> `<start_of_turn>`model\n",
+    ">\n",
+    "> Category: Food\n",
+    ">\n",
+    "> Jollof rice is a popular and iconic one-pot rice dish that is a staple in many West African countries.`<end_of_turn>`\n",
+    "------\n",
+    "\n",
+    "Run the following cell to load the Africa Galore QA dataset and format each example so that it has this structure."
+   ],
+   "metadata": {
+    "id": "rC4ZM0nap6OV"
+   }
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "# Load the question-answer dataset.\n",
+    "africa_galore_qa = pd.read_json(\n",
+    "    \"https://storage.googleapis.com/dm-educational/assets/ai_foundations/africa_galore_qa_v2.json\"\n",
+    ")\n",
+    "\n",
+    "questions = []  # List of formatted questions.\n",
+    "answers = []  # List of formatted answers.\n",
+    "\n",
+    "for idx, row in africa_galore_qa.iterrows():\n",
+    "    # Run the format_qa function from the previous lab to format the question\n",
+    "    # and the answer.\n",
+    "    question, answer = formatting.format_qa(row)\n",
+    "    questions.append(question)\n",
+    "    answers.append(answer)\n",
+    "\n",
+    "# Show the first set of inputs and outputs.\n",
+    "print(questions[0])\n",
+    "print(fill(answers[0], replace_whitespace=False))"
+   ],
+   "metadata": {
+    "id": "5Ra4HE2Y_FaT"
+   },
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Recall that in the previous lab, you had to perform additional steps for preparing the data. You also had to tokenize each question and each answer and you had to manually replace some tokens in the target with the special `<PAD>` token to exclude it from the loss computation.\n",
+    "\n",
+    "Since fine-tuning a model is a very common task, implementations of models like Gemma often already implement functions that take care of several steps of data preparation as part of a preprocessor.\n",
+    "\n",
+    "In the case of the Keras implementation of the Gemma model, you only need to specify the prompt and what you would like the model to generate. It then automatically constructs tokenized examples that can be used to fine-tune a Gemma language model. In the background, it concatenates the prompts and responses and excludes the tokens in the prompt from the loss computation. This saves you many common steps. Note, however, that it does not automatically add `<start_of_turn>` or `<end_of_turn>` tokens, so you still have to provide these tokens to the model, as you did in the previous cell."
+   ],
+   "metadata": {
+    "id": "Z04UnLYebZlL"
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Preparing data for the Keras model\n",
+    "\n",
+    "The Keras implementation of Gemma expects the fine-tuning data to be structured as a Python dictionary with two specific keys: `prompts` for the prompts (these are the questions in the case of the flashcard generator) and `responses` for the generations that the model should output (the answers in the case of the flashcard generator).\n",
+    "\n",
+    "Run the following cell to initialize this dictionary."
+   ],
+   "metadata": {
+    "id": "s7yrCJJisdee"
+   }
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "data = {\n",
+    "    \"prompts\": questions,\n",
+    "    \"responses\": answers\n",
+    "}"
+   ],
+   "metadata": {
+    "id": "xspsmEJbpcS9"
+   },
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Loading the Gemma model with Keras\n",
+    "\n",
+    "The following cell loads the pre-trained [Gemma-1B model](https://ai.google.dev/gemma/docs/core/prompt-structure) using Keras [2]. Like your SLM, this model has been trained on the next-word prediction task and it has not been optimized for answering questions. After loading, you can print a summary using the `summary` method to inspect its architecture.\n",
+    "\n",
+    "------\n",
+    "> **💭 Reflection: Memory requirements**\n",
+    ">\n",
+    "> Before running the code, consider the following questions:\n",
+    ">\n",
+    "> * How many parameters do you expect the model to have?\n",
+    "> * If you are using a Colab notebook with a T4 GPU, it will have about 15GB of memory. Will you be able to load the entire model into the memory of your GPU?\n",
+    "> * Would a much larger model, like Gemma-27B, fit on your GPU?\n",
+    ">\n",
+    "------\n",
+    "\n",
+    "Run the following cell to load the model and initialize the preprocessor.\n",
+    "\n",
+    "\n"
+   ],
+   "metadata": {
+    "id": "rQfwovolu46v"
+   }
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "# Load the Gemma3-1B Keras model.\n",
+    "model = keras_nlp.models.Gemma3CausalLM.from_preset(\"gemma3_1b\")\n",
+    "model.summary()\n",
+    "\n",
+    "# Set the maximum sequence length of the model for padding and batching.\n",
+    "model.preprocessor.sequence_length = 400"
+   ],
+   "metadata": {
+    "id": "ZKvAc-Hx7QAa"
+   },
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "#### Understanding Gemma's Memory Footprint"
+   ],
+   "metadata": {
+    "id": "Hhtv392yt11v"
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "The Gemma 1B model has approximately 1.3 billion parameters (1B for the main transformer blocks and 300M for the token embeddings). A model of this size typically requires around 4GB of memory, so it fits on a T4 GPU with 15GB of memory. However, a 27B model, that is a model with around 27 billion parameters would require roughly 100 GB of memory (27 $\\times$ ~3.7 GB), which exceeds the capacity of a single T4 GPU multiple times.\n",
+    "\n"
+   ],
+   "metadata": {
+    "id": "rzi9osL_w1F3"
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Prompting the base model\n",
+    "\n",
+    "Before you fine-tune the model, observe how the pre-trained base model performs when you prompt it with a question.\n"
+   ],
+   "metadata": {
+    "id": "MrLhNUOKxkZg"
+   }
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "prompt = \"What is Jollof rice?\"\n",
+    "response = model.generate(prompt, max_length=200)\n",
+    "print(fill(response, replace_whitespace=False))"
+   ],
+   "metadata": {
+    "id": "C9Lan88tx73I"
+   },
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### What did you observe?\n",
+    "\n",
+    "For a prompt such as \"What is Jollof rice?\", you likely observed that the model's response contains repetitions, is not concise and may go off topic. Furthermore, it does not output the response in the desired flashcard format.\n",
+    "\n",
+    "These shortcomings are expected. Recall that this model has been trained on large amounts of text data to predict the next token but, unlike instruction-tuned models, it has not been optimized to respond to user queries. Furthermore, its pre-training does not contain any information about the format for the flashcard generator.\n",
+    "\n",
+    "By fine-tuning a model you can address both of these issues. The model will learn to produce more concise responses to questions and learn to follow the flashcard format, since both of these qualities are demonstrated in the training examples of the Africa Galore QA dataset."
+   ],
+   "metadata": {
+    "id": "endeHMkAyERI"
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Attempting full-parameter fine-tuning\n",
+    "\n",
+    "Fine-tuning requires significantly more memory than using a model for inference. For each parameter, the training process must store not only the current value of the parameter itself, but also the gradient and other variables used by the optimizer. Because of this, training a model requires several times more memory than using a model for generations."
+   ],
+   "metadata": {
+    "id": "rt1-4R0iyVXX"
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "For this step, run the following code to fine-tune the Gemma-1B model using the same full-parameter approach that you used for fine-tuning your SLM. The code below updates all of Gemma's parameters.\n",
+    "\n",
+    "Note that if you encounter an error while running fine-tuning, continue reading on for guidance."
+   ],
+   "metadata": {
+    "id": "bTLtTY6Uy95J"
+   }
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "model.fit(data, epochs=1, batch_size=32, verbose=1)"
+   ],
+   "metadata": {
+    "id": "r2A8rJJt-3TG"
+   },
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### What did you observe?\n",
+    "\n",
+    "\n",
+    "When running the cell above, you should observe an \"out of memory\" (OOM) error. This occurred because the optimizer attempted to allocate more memory than is available on a T4 GPU when trying to fine-tune all 1.3 billion parameters of the Gemma-1B model. When this happens, the entire Colab session will crash and you have to re-run all of the code again.\n",
+    "\n",
+    "This is an intentional step that highlights that you may be able to load models with more than 1B parameters and perform inference on a T4 GPU with 15GB, as you did earlier in this lab, but this does not mean that you can also fine-tune all parameters of such a model. As you will learn in more detail in future courses, any form of model training, including fine-tuning, requires significantly more memory, since you also have to store gradients and information for the optimizer in the GPU's memory.\n",
+    "\n",
+    "\n",
+    "\n"
+   ],
+   "metadata": {
+    "id": "jZoyh3jwzp4A"
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Summary\n",
+    "\n",
+    "In this lab, you experimented with the pre-trained Gemma-1B model. You attempted to adapt it to a new task using full-parameter fine-tuning and discovered that this method is often impractical for large models due to prohibitive memory requirements.\n",
+    "\n",
+    "To solve this, you need a more sophisticated approach. The upcoming labs will introduce you to the concept of parameter-efficient fine-tuning (PEFT) and a technique called LoRA, which will allow you to fine-tune large models, such as Gemma, with limited GPU memory."
+   ],
+   "metadata": {
+    "id": "tuWmXJiQUaiS"
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## References\n",
+    "\n",
+    "[1] Google AI - Gemma Prompt Structure\n",
+    "Google AI. 2025. Gemma formatting and system instructions. Retrieved from https://ai.google.dev/gemma/docs/core/prompt-structure\n",
+    "\n",
+    "[2] Keras Hub - Gemma3CausalLM\n",
+    "Keras. 2025. Gemma3CausalLM model. Retrieved from https://keras.io/keras_hub/api/models/gemma3/gemma3_causal_lm/\n",
+    "\n",
+    "\n",
+    "\n",
+    "\n",
+    "\n"
+   ],
+   "metadata": {
+    "id": "_1fqgdQSv-Gv"
+   }
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "collapsed_sections": [
+    "NDWsJUGcf4Ru"
+   ],
+   "provenance": [],
+   "gpuType": "T4"
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  },
+  "accelerator": "GPU"
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
 }

--- a/course_5/gdm_lab_5_6_fine_tune_gemma_with_lora.ipynb
+++ b/course_5/gdm_lab_5_6_fine_tune_gemma_with_lora.ipynb
@@ -1,793 +1,708 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "McySAWvt09wn"
-      },
-      "source": [
-        "> <p><small><small>This Notebook is made available subject to the licence and terms set out in the <a href = \"http://www.github.com/google-deepmind/ai-foundations\">AI Research Foundations Github README file</a>."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "bg_nGpxOxaPv"
-      },
-      "source": [
-        "<img src=\"https://storage.googleapis.com/dm-educational/assets/ai_foundations/GDM-Labs-banner-image-C5-white-bg.png\">"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "6bW1AyB_f7eo"
-      },
-      "source": [
-        "# Lab: Fine-Tune Gemma with LoRA\n",
-        "\n",
-        "<a href='https://colab.research.google.com/github/google-deepmind/ai-foundations/blob/master/course_5/gdm_lab_5_6_fine_tune_gemma_with_lora.ipynb' target='_parent'><img src='https://colab.research.google.com/assets/colab-badge.svg' alt='Open In Colab'/></a>\n",
-        "\n",
-        "30 minutes understanding + 20 minutes computation time\n",
-        "\n",
-        "Explore how you can fine-tune larger pre-trained models by applying LoRA.\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "md4FSU7h9dQR"
-      },
-      "source": [
-        "## Overview\n",
-        "\n",
-        "Recall that in the lab \"Full-Parameter Fine-Tuning of Gemma,\" your training process failed due to an out-of-memory error. In this lab, you will explore how this can be avoided by applying LoRA when fine-tuning a Gemma model. This will allow you to fine-tune Gemma for your flashcard generation task. You will also explore the advantages of fine-tuning a large pre-trained model, such as how it can answer questions on a range of topics due to the diverse data that it has been pre-trained on.\n",
-        "\n",
-        "\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "g8u6btAn9jc4"
-      },
-      "source": [
-        "### What you will learn:\n",
-        "\n",
-        "By the end of this lab, you will be able to:\n",
-        "\n",
-        "* Apply LoRA to Gemma-1B.\n",
-        "* Fine-tune a model for your own task.\n",
-        "* Evaluate what the fine-tuned model learned from pre-training.\n",
-        "* Evaluate what the fine-tuned model learned from fine-tuning.\n",
-        "* Describe how combining knowledge from both training processes allows it to perform in ways that could not be achieved with either type of training alone.\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "qIhcVxx0foVo"
-      },
-      "source": [
-        "### Tasks\n",
-        "\n",
-        "**In this lab, you will**:\n",
-        "* Repeat the steps from lab \"Large pre-trained models\" to load and prepare Gemma-1B.\n",
-        "* Prepare Gemma-1B for fine-tuning with LoRA.\n",
-        "* Choose the hyperparameters for fine-tuning.\n",
-        "* Monitor the fine-tuning process.\n",
-        "* Evaluate the performance of the pre-trained and fine-tuned model.\n",
-        "\n",
-        "**This lab needs to be run on a GPU. Choose a T4 GPU.** See the section \"How to use Google Colaboratory (Colab)\" below for instructions on how to do this.\n",
-        "\n",
-        "**You also need a Kaggle account** to download the weights of the Gemma 3 model. See the section \"Set up a Kaggle account\" for instructions on how to do this.\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "NDWsJUGcf4Ru"
-      },
-      "source": [
-        "## How to use Google Colaboratory (Colab)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "wlNG_jg-39Zj"
-      },
-      "source": [
-        "Google Colaboratory (also known as Google Colab) is a platform that allows you to run Python code in your browser. The code is written in cells that are executed on a remote server.\n",
-        "\n",
-        "To run a cell, hover over a cell, and click the `run` button to its left. The run button is the circle with the triangle (▶). Alternatively, you can also click a cell and use the keyboard combination Ctrl+Return (or ⌘+Return if you are using a Mac).\n",
-        "\n",
-        "To try this out, run the following cell. This should print today's day of the week below it."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "UyTT6C0JhGBs"
-      },
-      "outputs": [],
-      "source": [
-        "from datetime import datetime\n",
-        "print(f\"Today is {datetime.today():%A}.\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "pbtgZxrpjm6j"
-      },
-      "source": [
-        "Note that the order in which you run the cells matters. When you are working through a lab, make sure to always run all cells in order. Otherwise, the code might not work. If you take a break while working on a lab, Colab may disconnect you; in that case, you have to execute all cells again before  continuing your work. To make this easier, you can select the cell you are currently working on and then choose __Runtime → Run before__  from the menu above (or use the keyboard combination Ctrl/⌘ + F8). This will re-execute all cells before the current one."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "qLvkcx5pUItk"
-      },
-      "source": [
-        "### Using Colab with a GPU\n",
-        "\n",
-        "Follow these steps to run the activities in this lab on a GPU:\n",
-        "\n",
-        "1.  In the top menu bar, click **Runtime**.\n",
-        "2.  Select **Change runtime type** from the dropdown menu.\n",
-        "3.  In the pop-up window under **Hardware Accelerator**, select **GPU** (usually listed as `T4 GPU`).\n",
-        "4.  Click **Save**.\n",
-        "\n",
-        "Your Colab session will now restart with GPU access.\n",
-        "\n",
-        "Note that access to GPUs is limited and at times, you may not be able to run this lab on a GPU. All activities will still work but they will run slower and you will have to wait longer for some of the cells to finish running.\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "## Set up a Kaggle account\n"
-      ],
-      "metadata": {
-        "id": "n6-dSJ-o_JT9"
-      }
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "\n",
-        "To run this notebook, you will have to sign up for [Kaggle](https://www.kaggle.com), a platform that hosts datasets and models for machine learning, and sign the agreement for using the Gemma 3 model. This is required so that you can download the weights of the Gemma model for fine-tuning.\n",
-        "\n",
-        "### Step 1: Create your Kaggle account\n",
-        "\n",
-        "* Go to the Kaggle website: https://www.kaggle.com\n",
-        "\n",
-        "* Click the \"Register\" button in the top-right corner.\n",
-        "\n",
-        "* You can sign up using your Google account (recommended for easy Colab integration) or by entering an email and password.\n",
-        "\n",
-        "* Follow the on-screen prompts to complete your registration and verify your email.\n",
-        "\n",
-        "### Step 2: Sign the Gemma 3 model agreement\n",
-        "\n",
-        "* Make sure you are logged into your new Kaggle account.\n",
-        "\n",
-        "* Go directly to the Gemma 3 model card page: https://www.kaggle.com/models/keras/gemma3/keras/\n",
-        "\n",
-        "* You should see a \"Request Access\" button.\n",
-        "\n",
-        "* Click the button, read through the license agreement, and click \"Accept\" to gain access to the model. You must do this before the API will let you download the model.\n",
-        "\n",
-        "### Step 3: Generate your Kaggle API key\n",
-        "\n",
-        "* From any Kaggle page, click on your profile picture or icon in the top-right corner.\n",
-        "\n",
-        "* Select \"Account\" from the drop-down menu.\n",
-        "\n",
-        "* Scroll down to the \"API\" section.\n",
-        "\n",
-        "* Click the \"Create New API Token\" button.\n",
-        "\n",
-        "* This will immediately download a file named `kaggle.json` to your computer. This file contains your username and your secret API key. Keep it safe.\n",
-        "\n",
-        "### Step 4: Set your API Key in  Colab\n",
-        "\n",
-        "* Click the \"key\" icon 🔑 in the left-hand sidebar.\n",
-        "\n",
-        "* You will see the \"Secrets\" panel.\n",
-        "\n",
-        "* Now, open the kaggle.json file you downloaded on your computer. It's a simple text file and will look like this:\n",
-        "\n",
-        "   ```json\n",
-        "   {\"username\":\"YOUR_KAGGLE_USERNAME\",\"key\":\"YOUR_KAGGLE_API_KEY\"}\n",
-        "   ```\n",
-        "* In the Colab Secrets panel, create two new secrets:\n",
-        "\n",
-        "   1. Name: `KAGGLE_USERNAME`\n",
-        "\n",
-        "      Value: Copy and paste `YOUR_KAGGLE_USERNAME` from your `kaggle.json` file.\n",
-        "\n",
-        "   2. Name: `KAGGLE_KEY`\n",
-        "\n",
-        "      Value: Copy and paste `YOUR_KAGGLE_API_KEY` from your `kaggle.json` file.\n",
-        "\n",
-        "* For both secrets, make sure the \"Notebook access\" toggle is switched on.\n"
-      ],
-      "metadata": {
-        "id": "9iS70YEC_Hx8"
-      }
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "## Imports\n",
-        "\n",
-        "In this lab, you will use the Keras package for loading a Gemma model and the Pandas package to load the dataset.\n",
-        "\n",
-        "Run the following cell to import the required packages."
-      ],
-      "metadata": {
-        "id": "kWYRbwY7pBV9"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "%%capture\n",
-        "# Install the custom package for this course.\n",
-        "!pip install \"git+https://github.com/google-deepmind/ai-foundations.git@main\"\n",
-        "\n",
-        "import os\n",
-        "\n",
-        "from google.colab import userdata\n",
-        "\n",
-        "os.environ[\"KAGGLE_USERNAME\"] = userdata.get(\"KAGGLE_USERNAME\")\n",
-        "os.environ[\"KAGGLE_KEY\"] = userdata.get(\"KAGGLE_KEY\")\n",
-        "\n",
-        "os.environ[\"KERAS_BACKEND\"] = \"jax\"  # Set the Keras backend to JAX.\n",
-        "\n",
-        "import json # For loading training logs.\n",
-        "from urllib import request # For downloading training logs.\n",
-        "import keras # For training the model.\n",
-        "import keras_nlp # For loading Gemma-1B.\n",
-        "import pandas as pd # For loading the dataset.\n",
-        "import jax.numpy as jnp # For working with matrices and vectors.\n",
-        "from textwrap import fill # For formatting long paragraphs.\n",
-        "# For loading the formatting function that you implemented in previous labs.\n",
-        "from ai_foundations import formatting\n",
-        "\n",
-        "# Avoids memory fragmentation on JAX backend.\n",
-        "os.environ[\"XLA_PYTHON_CLIENT_MEM_FRACTION\"] = \"0.95\"\n",
-        "keras.utils.set_random_seed(812)  # For making the training reproducible."
-      ],
-      "metadata": {
-        "id": "TAQmA4Vl7PTM"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "## Fine-tune Gemma 3 with LoRA"
-      ],
-      "metadata": {
-        "id": "MaICqS1MOP8e"
-      }
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "### Prepare the data and load the model\n",
-        "\n",
-        "The following cells implement the data preparation steps and load the Gemma-1B model. These are the same steps as you performed when you attempted to perform full-parameter fine-tuning with Gemma."
-      ],
-      "metadata": {
-        "id": "GSuKAcfmZuvL"
-      }
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "#### Load and format the fine-tuning data\n",
-        "\n",
-        "For adding the special delimiters, you will again use the `format_qa` function that you have implemented earlier. Additionally, the following cell also defines a function `format_question` for formatting only a question. This function can be used for formatting prompts when you evaluate the model.\n",
-        "\n",
-        "The following cell defines the `format_question`, loads the Africa Galore QA dataset, and creates the data dictionary that can be used to fine-tune the Keras implementation of Gemma."
-      ],
-      "metadata": {
-        "id": "8xSlinJIsPrA"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "def format_question(\n",
-        "    question: str,\n",
-        "    sot: str = \"<start_of_turn>\",\n",
-        "    eot: str = \"<end_of_turn>\"\n",
-        ") -> str:\n",
-        "    \"\"\"\n",
-        "    Formats a question for prompting the model and adds special delimiters at\n",
-        "    the start and end of the question.\n",
-        "\n",
-        "    Args:\n",
-        "      text: The question to be formatted.\n",
-        "      sot: The token to mark the start of a turn.\n",
-        "      eot: The token to mark the end of a turn.\n",
-        "\n",
-        "    Returns:\n",
-        "      Formatted string of the question.\n",
-        "    \"\"\"\n",
-        "\n",
-        "    formatted_q = f\"{sot}user\\n{question}{eot}\\n\"\n",
-        "\n",
-        "    return formatted_q\n",
-        "\n",
-        "# Load the question-answer dataset.\n",
-        "africa_galore_qa = pd.read_json(\n",
-        "    \"https://storage.googleapis.com/dm-educational/assets/ai_foundations/africa_galore_qa_v2.json\"\n",
-        ")\n",
-        "\n",
-        "questions = []  # List of formatted questions.\n",
-        "answers = []  # List of formatted answers.\n",
-        "\n",
-        "for idx, row in africa_galore_qa.iterrows():\n",
-        "    # Run the format_qa function from the previous lab to format the question\n",
-        "    # and the answer.\n",
-        "    question, answer = formatting.format_qa(row)\n",
-        "    questions.append(question)\n",
-        "    answers.append(answer)\n",
-        "\n",
-        "# Show the first set of input and output.\n",
-        "print(questions[0])\n",
-        "print(fill(answers[0], replace_whitespace=False))\n",
-        "\n",
-        "# Prepare the data dictionary for fine-tuning Gemma.\n",
-        "data = {\n",
-        "    \"prompts\": questions,\n",
-        "    \"responses\": answers\n",
-        "}"
-      ],
-      "metadata": {
-        "id": "5Ra4HE2Y_FaT"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "#### Load the model\n",
-        "\n",
-        "Run the following cell to load the Gemma model and print a summary of its number of parameters.\n"
-      ],
-      "metadata": {
-        "id": "BTW_2zBsub98"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "# Load the Gemma-1B Keras model.\n",
-        "model = keras_nlp.models.Gemma3CausalLM.from_preset(\"gemma3_1b\")\n",
-        "model.summary()"
-      ],
-      "metadata": {
-        "id": "ZKvAc-Hx7QAa"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "### Prompt the pre-trained Gemma model\n",
-        "\n",
-        "Before fine-tuning the model, observe how the pre-trained model responds to prompts in the format that you have been using for the flashcard generator.\n",
-        "\n",
-        "Run the following cell to generate responses to three questions that you will use to evaluate your model throughout this lab:\n",
-        "\n",
-        "1. \"What is Kente cloth?\": A question that is present in the Africa Galore QA dataset.\n",
-        "2. \"What is the tallest mountain in Africa?\": A question that does not appear in the Africa Galore QA dataset but that is on a topic that is present in the fine-tuning dataset.\n",
-        "3. \"What is Mount Aconcagua?\": A question that does not appear in the fine-tuning dataset and that is on a topic that is not covered in the fine-tuning dataset.\n",
-        "\n",
-        "Inspect the answers to each of these questions."
-      ],
-      "metadata": {
-        "id": "-dHw67SiauZz"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "evaluation_prompts = [\n",
-        "    \"What is Kente cloth?\",\n",
-        "    \"What is the tallest mountain in Africa?\",\n",
-        "    \"What is Mount Aconcagua?\"\n",
-        "]\n",
-        "\n",
-        "# Predict answers for three formatted questions through the model.\n",
-        "# Generate answers with a length of (up to) 200 tokens.\n",
-        "for prompt in evaluation_prompts:\n",
-        "    formatted_prompt = format_question(prompt)\n",
-        "    model_response = model.generate(formatted_prompt, max_length=200)\n",
-        "    print(fill(model_response, replace_whitespace=False))\n",
-        "    print('\\n------\\n')"
-      ],
-      "metadata": {
-        "id": "SfUlJiBSATJd"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "#### What did you observe?\n",
-        "\n",
-        "You likely observed that when prompting a pre-trained model that has been only trained to predict the next token from a large corpus of texts, it may be able to produce some answers to questions. However, in many cases it will produce quite repetitive answers and sometimes it will generate similar questions rather than generating an appropriate answer.\n",
-        "\n",
-        "Furthermore, you likely noticed that the model did not generate the category or the turn-taking tokens for any of the questions. As such, it did not adhere to the format that you want for your flashcard generator."
-      ],
-      "metadata": {
-        "id": "4N8mDV1Ef88N"
-      }
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "### Activate LoRA\n",
-        "\n",
-        "LoRA is already implemented in the Keras implementation of Gemma and can be added with a call to the `enable_lora` method. For example, to enable LoRA with a rank of 4, you can call:\n",
-        "\n",
-        "```python\n",
-        "model.backbone.enable_lora(rank=4)\n",
-        "```\n",
-        "\n",
-        "Run the following cell to enable LoRA. Then consider the output of the summary method. Observe how the parameter count has slightly increased because of the additional LoRA parameters. At the same time, observe how the number of trainable parameters is much smaller than the number of total parameters."
-      ],
-      "metadata": {
-        "id": "-85NrBUOgg6F"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "model.backbone.enable_lora(rank=4)\n",
-        "model.summary()"
-      ],
-      "metadata": {
-        "id": "LIoaYWzy-s3W"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "## Activity 1: Setting hyperparameters\n",
-        "\n",
-        "The last step before you can start training is to set the hyperparameters of the training process. Recall that the two parameters that are particularly important for fine-tuning are the **learning rate** and the **number of epochs**, that is the number of times you iterate through the fine-tuning data during fine-tuning.\n",
-        "\n",
-        "For both of these parameters, you generally want to perform hyperparameter tuning and choose a set of parameters that leads to useful results on your evaluation examples. Note that you are using a model here that is different from your SLM and also you are training the model using LoRA instead of performing full-parameter fine-tuning. Therefore, the optimal hyperparameters may be different for fine-tuning the Gemma model than the ones you used to fine-tune your SLM.\n",
-        "\n",
-        "For pre-trained models like Gemma, a reasonable range for the number of epochs is usually 1 to 20, depending both on the size of your fine-tuning set and the learning rate. If you use a larger fine-tuning set and/or a higher learning rate, you generally need to fine-tune for fewer epochs. Conversely, if you have very few fine-tuning examples or use a very low learning rate, you will need to fine-tune for more epochs.\n",
-        "\n",
-        "For the learning rate, values between 0.0001 (1e-4) and 0.000001 (1e-6) tend to work well in practice for fine-tuning models like Gemma.\n",
-        "\n",
-        "<br>\n",
-        "\n",
-        "------\n",
-        "> **💻 Your task:**\n",
-        ">\n",
-        "> Find the right setting for the learning rate.\n",
-        ">\n",
-        "> In practice, you would fine-tune a model multiple times with different learning rates and evaluate the model performance during fine-tuning. You would then choose a learning rate that leads to the best evaluation results. However, since fine-tuning consumes a lot of GPU resources and your Colab GPU resources may be limited, the following cell provides you with the output of training runs with different learning rates.\n",
-        ">\n",
-        "> Select a learning rate and execute the cell to print the log of the training run with that specific learning rate. Look at the model generations after each epoch and choose a learning rate that leads to \"good\" results for all prompts.\n",
-        ">\n",
-        "------"
-      ],
-      "metadata": {
-        "id": "Bzfd9R-dAy0Z"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "# @title Training logs for different learning rates\n",
-        "\n",
-        "if \"training_logs\" not in globals():\n",
-        "    TRAINING_LOG_URL = \"https://storage.googleapis.com/dm-educational/assets/ai_foundations/finetune-gemma-training-logs.json\"\n",
-        "    with request.urlopen(TRAINING_LOG_URL) as json_file:\n",
-        "        training_logs = json.loads(json_file.read().decode())\n",
-        "\n",
-        "learning_rate = 1e-3 # @param [\"1e-3\",\"5e-4\",\"2e-4\",\"1e-4\",\"5e-5\",\"2e-5\",\"1e-5\",\"5e-6\",\"2e-6\",\"1e-6\"] {\"type\":\"raw\"}\n",
-        "\n",
-        "print(training_logs[str(learning_rate)])"
-      ],
-      "metadata": {
-        "id": "RiXiy6QkRxj1",
-        "cellView": "form"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "Once you have determined the optimal learning rate for this fine-tuning problem, add the learning rate to the following cell."
-      ],
-      "metadata": {
-        "id": "8_uspPwH8w8N"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "# Set the learning rate\n",
-        "model.optimizer.learning_rate = # Add your code here.\n",
-        "\n",
-        "# Set the number of epochs.\n",
-        "num_epochs = 10\n",
-        "\n",
-        "# Set the maximum length.\n",
-        "model.preprocessor.sequence_length = 400"
-      ],
-      "metadata": {
-        "id": "5P2iEx7piCzV"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "### Perform fine-tuning\n",
-        "\n",
-        "Now that you have prepared the data and set up the model and LoRA, fine-tuning can be done just like any other training in Keras, that is, with the `model.fit()` method.\n",
-        "\n",
-        "As previously, it is important to monitor the training progress using a callback function. Run the following cell to define a callback function that prints generations for the three evaluation prompts that you defined above.\n",
-        "\n"
-      ],
-      "metadata": {
-        "id": "eXSVDVgombdA"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "class EvaluationCallback(keras.callbacks.Callback):\n",
-        "    \"\"\"\n",
-        "    A Keras callback function to print generations for evaluation prompts.\n",
-        "    \"\"\"\n",
-        "    def on_epoch_end(self, epoch: int, logs=None):\n",
-        "        \"\"\"Prints generations for the three evaluation prompts.\n",
-        "\n",
-        "        Args:\n",
-        "          epoch: The current epoch.\n",
-        "          logs: The logs dictionary.\n",
-        "        \"\"\"\n",
-        "\n",
-        "        evaluation_prompts = [\n",
-        "            \"What is Kente cloth?\",\n",
-        "            \"What is the tallest mountain in Africa?\",\n",
-        "            \"What is Mount Aconcagua?\"\n",
-        "        ]\n",
-        "\n",
-        "        # Run three formatted questions through the model.\n",
-        "        # Generate answers with a length of (up to) 200 tokens.\n",
-        "        for prompt in evaluation_prompts:\n",
-        "            formatted_prompt = format_question(prompt)\n",
-        "            model_response = model.generate(formatted_prompt, max_length=200)\n",
-        "            print(fill(model_response, replace_whitespace=False))\n",
-        "            print('\\n------\\n')\n",
-        "\n",
-        "evaluation_callback = EvaluationCallback()"
-      ],
-      "metadata": {
-        "id": "VI_d54GPAhmH"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "------\n",
-        "> **💻 Your task:**\n",
-        ">\n",
-        ">Run the following cell to fine-tune your model.\n",
-        ">\n",
-        ">While the model is fine-tuning, monitor the fine-tuning progress using the three evaluation prompts.\n",
-        ">\n",
-        ">Keep note of:\n",
-        ">\n",
-        ">* When does the model begin to output \"\\<start_of_turn>model\"?\n",
-        ">* When does the model begin to produce outputs that start with \"Category:\" and the correct category?\n",
-        ">* At which epochs does the model produce very strange outputs?\n",
-        ">* From which epoch on does the model consistently produce a single paragraph and stop repeating texts?\n",
-        ">* At which epoch does the model start to produce \"\\<end_of_turn>\" and stop producing any other output thereafter?\n",
-        ">\n",
-        ">After the first epoch, the training will take about one to two minutes per epoch on a T4 GPU.  Expect that it takes 15 to 20 minutes in total for fine-tuning the model for 10 epochs.\n",
-        ">\n",
-        "------"
-      ],
-      "metadata": {
-        "id": "yjOQCTGTAg9O"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "training_history = model.fit(\n",
-        "    data,\n",
-        "    epochs=num_epochs,\n",
-        "    batch_size=1,\n",
-        "    verbose=1,\n",
-        "    callbacks=[evaluation_callback]\n",
-        ")"
-      ],
-      "metadata": {
-        "id": "VuAIS6BJMplA"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "\n",
-        "At the end of the fine-tuning process, did the model outputs satisfy all of the criteria mentioned above? If not, you may want to continue fine-tuning for a few more epochs.\n",
-        "\n",
-        "Overall, you likely noticed \"good\" performance, even for questions that are not about African culture and geography. For example, the question about the South American Mountain, \"What is Mount Aconcagua?\". You likely observed that the pre-trained model was able to provide an answer about this mountain and managed to do so in the desired format for the flashcard generator. In doing so, it managed to combine the factual information from its pre-training performed on a dataset of 2 trillion tokens with the specifics of the format that it learned from the fine-tuning examples."
-      ],
-      "metadata": {
-        "id": "j8ufZC7uqo-z"
-      }
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "## Additional evaluations\n",
-        "\n",
-        "As always, it is important to test your model on a wide range of questions. Define some more questions below and check the model outputs."
-      ],
-      "metadata": {
-        "id": "YcrLDX9lvE00"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "additional_prompts = [\n",
-        "    \"What is Mount Aconcagua?\",\n",
-        "    \"What is American Football?\",\n",
-        "    \"What is Python?\"\n",
-        "]\n",
-        "\n",
-        "for prompt in additional_prompts:\n",
-        "    formatted_prompt = format_question(prompt)\n",
-        "    model_response = model.generate(formatted_prompt, max_length=300)\n",
-        "    print(fill(model_response, replace_whitespace=False))\n",
-        "    print('\\n------\\n')"
-      ],
-      "metadata": {
-        "id": "UCTmTb4ECLWo"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "#### What did you observe?\n",
-        "\n",
-        "You likely observed that the model was able to infer appropriate categories for many questions and managed to output many reasonable responses.\n",
-        "\n",
-        "If the responses to all your questions were useful, try to find very niche topics and ask the model about them. Are you able to find the limits of this model?\n"
-      ],
-      "metadata": {
-        "id": "OJONdeXQIgIB"
-      }
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "## Summary\n",
-        "\n",
-        "In this lab you fine-tuned Gemma-1B with LoRA. You observed that the model could not only produce answers in the desired format for the topics that are present in the fine-tuning dataset (Africa Galore QA) but on a variety of topics.\n",
-        "\n",
-        "This process demonstrated the power of combining \"good\" pre-trained models with fine-tuning. It allows you to build highly capable models for many tasks with a small fine-tuning dataset."
-      ],
-      "metadata": {
-        "id": "zfbLYukJzVgA"
-      }
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "## Solutions\n",
-        "\n",
-        "The following cells provide reference solutions to the coding activities in this notebook. If you really get stuck after trying to solve the activities yourself, you may want to consult these solutions.\n",
-        "\n",
-        "It is recommended that you *only* look at the solutions after you have tried to solve the activities *multiple times*. The best way to learn challenging concepts in computer science and artificial intelligence is to debug your code piece-by-piece until it works, rather than copying existing solutions.\n",
-        "\n",
-        "If you feel stuck, you may want to first try to debug your code. For example, by adding additional print statements to see what your code is doing at every step. This will provide you with a much deeper understanding of the code and the materials. It will also provide you with practice on how to solve challenging coding problems beyond this course.\n",
-        "\n",
-        "To view the solutions for an activity, click the arrow to the left of the activity name. If you consult the solutions, do not copy and paste them into the cells above. Instead, look at them, and type them manually into the cell. This will help you understand where you went wrong.\n"
-      ],
-      "metadata": {
-        "id": "eMHZ2_UicETN"
-      }
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "### Activity 1"
-      ],
-      "metadata": {
-        "id": "1htAIUJxcSB0"
-      }
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "A good choice for the learning rate is 2e-5. With this setting, the answers stabilize after about 7 to 8 epochs and are factually correct.\n",
-        "\n",
-        "A lower learning rate is also possible. However, the lower the learning rate you choose, the more epochs you need for fine-tuning.\n",
-        "\n",
-        "Higher learning rates look good at first glance but the answers are of lower quality.\n",
-        "\n",
-        "The answers produced by a learning rate of 5e-5 do not mention that Tokyo is the capital city of Japan and give a more generic description that applies to very large cities in general. That being said, they may still be acceptable.\n",
-        "\n",
-        "A learning rate of 1e-4 leads to answers that contain factual errors. For example, Kilimanjaro is not the second highest peak in the world after Mount Everest. Kilimanjaro is known for many amazing facts, but not that it played a particular role in a 1952 ascent of Mount Everest. The first successful climb of Mount Everest happened one year later. Even higher learning rates have similar problems.\n",
-        "\n",
-        "As you will observe, it can be quite difficult to judge the correctness of answers. The \"destruction\" of pre-trained knowledge with higher learning rates can be difficult to spot. Catastrophic forgetting does not necessarily occur on all aspects but can be more subtle as for the Kilimanjaro answers for a learning rate of 1e-4. Therefore, it is important to choose validation prompts that you yourself can answer very well at expert level."
-      ],
-      "metadata": {
-        "id": "H7vm7kxkcWHj"
-      }
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "## References\n",
-        "\n",
-        "[1] Gemma Team, Google DeepMind. 2025. Gemma 3 technical report. https://arxiv.org/pdf/2503.19786\n",
-        "\n",
-        "[2] Edward Hu, Yelong Shen, Phillip Wallis, Zeyuan Allen-Zhu, Yuanzhi Li, Shean Wang, Lu Wang, and Weizhu Chen. 2022. LoRA: Low-rank adaptation of large language models. In *International Conference on Learning Representations (ICLR 2022)*. https://openreview.net/pdf?id=nZeVKeeFYf9\n",
-        "\n",
-        "[3] Dan Biderman, Jacob Portes, Jose Javier Gonzalez Ortiz, Mansheej Paul, Philip Greengard, Connor Jennings, Daniel King, Sam Havens, Vitaliy Chiley, Jonathan Frankle, Cody Blakeney, and John P. Cunningham. 2024. LoRA learns less and forgets less. *Transactions on Machine Learning Research*. https://openreview.net/forum?id=aloEru2qCG\n"
-      ],
-      "metadata": {
-        "id": "xF7JKexDcqvs"
-      }
-    }
-  ],
-  "metadata": {
-    "colab": {
-      "collapsed_sections": [
-        "NDWsJUGcf4Ru",
-        "eMHZ2_UicETN",
-        "1htAIUJxcSB0"
-      ],
-      "provenance": [],
-      "gpuType": "T4"
-    },
-    "kernelspec": {
-      "display_name": "Python 3",
-      "name": "python3"
-    },
-    "language_info": {
-      "name": "python"
-    },
-    "accelerator": "GPU"
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "McySAWvt09wn"
+   },
+   "source": [
+    "> <p><small><small>This Notebook is made available subject to the licence and terms set out in the <a href = \"http://www.github.com/google-deepmind/ai-foundations\">AI Research Foundations Github README file</a>."
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 0
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "bg_nGpxOxaPv"
+   },
+   "source": [
+    "<img src=\"https://storage.googleapis.com/dm-educational/assets/ai_foundations/GDM-Labs-banner-image-C5-white-bg.png\">"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "6bW1AyB_f7eo"
+   },
+   "source": [
+    "# Lab: Fine-Tune Gemma with LoRA\n",
+    "\n",
+    "<a href='https://colab.research.google.com/github/google-deepmind/ai-foundations/blob/master/course_5/gdm_lab_5_6_fine_tune_gemma_with_lora.ipynb' target='_parent'><img src='https://colab.research.google.com/assets/colab-badge.svg' alt='Open In Colab'/></a>\n",
+    "\n",
+    "30 minutes understanding + 20 minutes computation time\n",
+    "\n",
+    "Explore how you can fine-tune larger pre-trained models by applying LoRA.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "md4FSU7h9dQR"
+   },
+   "source": [
+    "## Overview\n",
+    "\n",
+    "Recall that in the lab \"Full-Parameter Fine-Tuning of Gemma,\" your training process failed due to an out-of-memory error. In this lab, you will explore how this can be avoided by applying LoRA when fine-tuning a Gemma model. This will allow you to fine-tune Gemma for your flashcard generation task. You will also explore the advantages of fine-tuning a large pre-trained model, such as how it can answer questions on a range of topics due to the diverse data that it has been pre-trained on.\n",
+    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "g8u6btAn9jc4"
+   },
+   "source": [
+    "### What you will learn:\n",
+    "\n",
+    "By the end of this lab, you will be able to:\n",
+    "\n",
+    "* Apply LoRA to Gemma-1B.\n",
+    "* Fine-tune a model for your own task.\n",
+    "* Evaluate what the fine-tuned model learned from pre-training.\n",
+    "* Evaluate what the fine-tuned model learned from fine-tuning.\n",
+    "* Describe how combining knowledge from both training processes allows it to perform in ways that could not be achieved with either type of training alone.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "qIhcVxx0foVo"
+   },
+   "source": [
+    "### Tasks\n",
+    "\n",
+    "**In this lab, you will**:\n",
+    "* Repeat the steps from lab \"Large pre-trained models\" to load and prepare Gemma-1B.\n",
+    "* Prepare Gemma-1B for fine-tuning with LoRA.\n",
+    "* Choose the hyperparameters for fine-tuning.\n",
+    "* Monitor the fine-tuning process.\n",
+    "* Evaluate the performance of the pre-trained and fine-tuned model.\n",
+    "\n",
+    "**This lab needs to be run on a GPU. Choose a T4 GPU.** See the section \"How to use Google Colaboratory (Colab)\" below for instructions on how to do this.\n",
+    "\n",
+    "**You also need a Kaggle account** to download the weights of the Gemma 3 model. See the section \"Set up a Kaggle account\" for instructions on how to do this.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "NDWsJUGcf4Ru"
+   },
+   "source": [
+    "## How to use Google Colaboratory (Colab)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "wlNG_jg-39Zj"
+   },
+   "source": [
+    "Google Colaboratory (also known as Google Colab) is a platform that allows you to run Python code in your browser. The code is written in cells that are executed on a remote server.\n",
+    "\n",
+    "To run a cell, hover over a cell, and click the `run` button to its left. The run button is the circle with the triangle (▶). Alternatively, you can also click a cell and use the keyboard combination Ctrl+Return (or ⌘+Return if you are using a Mac).\n",
+    "\n",
+    "To try this out, run the following cell. This should print today's day of the week below it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "UyTT6C0JhGBs"
+   },
+   "outputs": [],
+   "source": [
+    "from datetime import datetime\n",
+    "print(f\"Today is {datetime.today():%A}.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "pbtgZxrpjm6j"
+   },
+   "source": [
+    "Note that the order in which you run the cells matters. When you are working through a lab, make sure to always run all cells in order. Otherwise, the code might not work. If you take a break while working on a lab, Colab may disconnect you; in that case, you have to execute all cells again before  continuing your work. To make this easier, you can select the cell you are currently working on and then choose __Runtime → Run before__  from the menu above (or use the keyboard combination Ctrl/⌘ + F8). This will re-execute all cells before the current one."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "qLvkcx5pUItk"
+   },
+   "source": [
+    "### Using Colab with a GPU\n",
+    "\n",
+    "Follow these steps to run the activities in this lab on a GPU:\n",
+    "\n",
+    "1.  In the top menu bar, click **Runtime**.\n",
+    "2.  Select **Change runtime type** from the dropdown menu.\n",
+    "3.  In the pop-up window under **Hardware Accelerator**, select **GPU** (usually listed as `T4 GPU`).\n",
+    "4.  Click **Save**.\n",
+    "\n",
+    "Your Colab session will now restart with GPU access.\n",
+    "\n",
+    "Note that access to GPUs is limited and at times, you may not be able to run this lab on a GPU. All activities will still work but they will run slower and you will have to wait longer for some of the cells to finish running.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Set up a Kaggle account\n"
+   ],
+   "metadata": {
+    "id": "n6-dSJ-o_JT9"
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": "\nTo run this notebook, you will have to sign up for [Kaggle](https://www.kaggle.com), a platform that hosts datasets and models for machine learning, and sign the agreement for using the Gemma 3 model. This is required so that you can download the weights of the Gemma model for fine-tuning.\n\n### Step 1: Create your Kaggle account\n\n* Go to the Kaggle website: https://www.kaggle.com\n\n* Click the \"Register\" button in the top-right corner.\n\n* You can sign up using your Google account (recommended for easy Colab integration) or by entering an email and password.\n\n* Follow the on-screen prompts to complete your registration and verify your email.\n\n### Step 2: Sign the Gemma 3 model agreement\n\n* Make sure you are logged into your new Kaggle account.\n\n* Go directly to the Gemma 3 model card page: https://www.kaggle.com/models/keras/gemma3/keras/\n\n* You should see a \"Request Access\" button.\n\n* Click the button, read through the license agreement, and click \"Accept\" to gain access to the model. You must do this before the API will let you download the model.\n\n### Step 3: Generate your Kaggle API token\n\n* From any Kaggle page, click on your profile picture or icon in the top-right corner.\n\n* Select \"Settings\" from the drop-down menu.\n\n* Scroll down to the \"API\" section.\n\n* Click the \"Generate New Token\" button.\n\n* Copy the token value that is displayed.\n\n### Step 4: Set your API token in Colab\n\n* Click the \"key\" icon 🔑 in the left-hand sidebar.\n\n* You will see the \"Secrets\" panel.\n\n* In the Colab Secrets panel, create a new secret:\n\n   * Name: `KAGGLE_API_TOKEN`\n\n   * Value: Paste the token you copied in Step 3.\n\n* Make sure the \"Notebook access\" toggle is switched on.",
+   "metadata": {
+    "id": "9iS70YEC_Hx8"
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Imports\n",
+    "\n",
+    "In this lab, you will use the Keras package for loading a Gemma model and the Pandas package to load the dataset.\n",
+    "\n",
+    "Run the following cell to import the required packages."
+   ],
+   "metadata": {
+    "id": "kWYRbwY7pBV9"
+   }
+  },
+  {
+   "cell_type": "code",
+   "source": "%%capture\n# Install the custom package for this course.\n!pip install \"git+https://github.com/google-deepmind/ai-foundations.git@main\"\n\nimport os\n\nfrom google.colab import userdata\n\nos.environ[\"KAGGLE_API_TOKEN\"] = userdata.get(\"KAGGLE_API_TOKEN\")\n\nos.environ[\"KERAS_BACKEND\"] = \"jax\"  # Set the Keras backend to JAX.\n\nimport json # For loading training logs.\nfrom urllib import request # For downloading training logs.\nimport keras # For training the model.\nimport keras_nlp # For loading Gemma-1B.\nimport pandas as pd # For loading the dataset.\nimport jax.numpy as jnp # For working with matrices and vectors.\nfrom textwrap import fill # For formatting long paragraphs.\n# For loading the formatting function that you implemented in previous labs.\nfrom ai_foundations import formatting\n\n# Avoids memory fragmentation on JAX backend.\nos.environ[\"XLA_PYTHON_CLIENT_MEM_FRACTION\"] = \"0.95\"\nkeras.utils.set_random_seed(812)  # For making the training reproducible.",
+   "metadata": {
+    "id": "TAQmA4Vl7PTM"
+   },
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Fine-tune Gemma 3 with LoRA"
+   ],
+   "metadata": {
+    "id": "MaICqS1MOP8e"
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Prepare the data and load the model\n",
+    "\n",
+    "The following cells implement the data preparation steps and load the Gemma-1B model. These are the same steps as you performed when you attempted to perform full-parameter fine-tuning with Gemma."
+   ],
+   "metadata": {
+    "id": "GSuKAcfmZuvL"
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "#### Load and format the fine-tuning data\n",
+    "\n",
+    "For adding the special delimiters, you will again use the `format_qa` function that you have implemented earlier. Additionally, the following cell also defines a function `format_question` for formatting only a question. This function can be used for formatting prompts when you evaluate the model.\n",
+    "\n",
+    "The following cell defines the `format_question`, loads the Africa Galore QA dataset, and creates the data dictionary that can be used to fine-tune the Keras implementation of Gemma."
+   ],
+   "metadata": {
+    "id": "8xSlinJIsPrA"
+   }
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "def format_question(\n",
+    "    question: str,\n",
+    "    sot: str = \"<start_of_turn>\",\n",
+    "    eot: str = \"<end_of_turn>\"\n",
+    ") -> str:\n",
+    "    \"\"\"\n",
+    "    Formats a question for prompting the model and adds special delimiters at\n",
+    "    the start and end of the question.\n",
+    "\n",
+    "    Args:\n",
+    "      text: The question to be formatted.\n",
+    "      sot: The token to mark the start of a turn.\n",
+    "      eot: The token to mark the end of a turn.\n",
+    "\n",
+    "    Returns:\n",
+    "      Formatted string of the question.\n",
+    "    \"\"\"\n",
+    "\n",
+    "    formatted_q = f\"{sot}user\\n{question}{eot}\\n\"\n",
+    "\n",
+    "    return formatted_q\n",
+    "\n",
+    "# Load the question-answer dataset.\n",
+    "africa_galore_qa = pd.read_json(\n",
+    "    \"https://storage.googleapis.com/dm-educational/assets/ai_foundations/africa_galore_qa_v2.json\"\n",
+    ")\n",
+    "\n",
+    "questions = []  # List of formatted questions.\n",
+    "answers = []  # List of formatted answers.\n",
+    "\n",
+    "for idx, row in africa_galore_qa.iterrows():\n",
+    "    # Run the format_qa function from the previous lab to format the question\n",
+    "    # and the answer.\n",
+    "    question, answer = formatting.format_qa(row)\n",
+    "    questions.append(question)\n",
+    "    answers.append(answer)\n",
+    "\n",
+    "# Show the first set of input and output.\n",
+    "print(questions[0])\n",
+    "print(fill(answers[0], replace_whitespace=False))\n",
+    "\n",
+    "# Prepare the data dictionary for fine-tuning Gemma.\n",
+    "data = {\n",
+    "    \"prompts\": questions,\n",
+    "    \"responses\": answers\n",
+    "}"
+   ],
+   "metadata": {
+    "id": "5Ra4HE2Y_FaT"
+   },
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "#### Load the model\n",
+    "\n",
+    "Run the following cell to load the Gemma model and print a summary of its number of parameters.\n"
+   ],
+   "metadata": {
+    "id": "BTW_2zBsub98"
+   }
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "# Load the Gemma-1B Keras model.\n",
+    "model = keras_nlp.models.Gemma3CausalLM.from_preset(\"gemma3_1b\")\n",
+    "model.summary()"
+   ],
+   "metadata": {
+    "id": "ZKvAc-Hx7QAa"
+   },
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Prompt the pre-trained Gemma model\n",
+    "\n",
+    "Before fine-tuning the model, observe how the pre-trained model responds to prompts in the format that you have been using for the flashcard generator.\n",
+    "\n",
+    "Run the following cell to generate responses to three questions that you will use to evaluate your model throughout this lab:\n",
+    "\n",
+    "1. \"What is Kente cloth?\": A question that is present in the Africa Galore QA dataset.\n",
+    "2. \"What is the tallest mountain in Africa?\": A question that does not appear in the Africa Galore QA dataset but that is on a topic that is present in the fine-tuning dataset.\n",
+    "3. \"What is Mount Aconcagua?\": A question that does not appear in the fine-tuning dataset and that is on a topic that is not covered in the fine-tuning dataset.\n",
+    "\n",
+    "Inspect the answers to each of these questions."
+   ],
+   "metadata": {
+    "id": "-dHw67SiauZz"
+   }
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "evaluation_prompts = [\n",
+    "    \"What is Kente cloth?\",\n",
+    "    \"What is the tallest mountain in Africa?\",\n",
+    "    \"What is Mount Aconcagua?\"\n",
+    "]\n",
+    "\n",
+    "# Predict answers for three formatted questions through the model.\n",
+    "# Generate answers with a length of (up to) 200 tokens.\n",
+    "for prompt in evaluation_prompts:\n",
+    "    formatted_prompt = format_question(prompt)\n",
+    "    model_response = model.generate(formatted_prompt, max_length=200)\n",
+    "    print(fill(model_response, replace_whitespace=False))\n",
+    "    print('\\n------\\n')"
+   ],
+   "metadata": {
+    "id": "SfUlJiBSATJd"
+   },
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "#### What did you observe?\n",
+    "\n",
+    "You likely observed that when prompting a pre-trained model that has been only trained to predict the next token from a large corpus of texts, it may be able to produce some answers to questions. However, in many cases it will produce quite repetitive answers and sometimes it will generate similar questions rather than generating an appropriate answer.\n",
+    "\n",
+    "Furthermore, you likely noticed that the model did not generate the category or the turn-taking tokens for any of the questions. As such, it did not adhere to the format that you want for your flashcard generator."
+   ],
+   "metadata": {
+    "id": "4N8mDV1Ef88N"
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Activate LoRA\n",
+    "\n",
+    "LoRA is already implemented in the Keras implementation of Gemma and can be added with a call to the `enable_lora` method. For example, to enable LoRA with a rank of 4, you can call:\n",
+    "\n",
+    "```python\n",
+    "model.backbone.enable_lora(rank=4)\n",
+    "```\n",
+    "\n",
+    "Run the following cell to enable LoRA. Then consider the output of the summary method. Observe how the parameter count has slightly increased because of the additional LoRA parameters. At the same time, observe how the number of trainable parameters is much smaller than the number of total parameters."
+   ],
+   "metadata": {
+    "id": "-85NrBUOgg6F"
+   }
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "model.backbone.enable_lora(rank=4)\n",
+    "model.summary()"
+   ],
+   "metadata": {
+    "id": "LIoaYWzy-s3W"
+   },
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Activity 1: Setting hyperparameters\n",
+    "\n",
+    "The last step before you can start training is to set the hyperparameters of the training process. Recall that the two parameters that are particularly important for fine-tuning are the **learning rate** and the **number of epochs**, that is the number of times you iterate through the fine-tuning data during fine-tuning.\n",
+    "\n",
+    "For both of these parameters, you generally want to perform hyperparameter tuning and choose a set of parameters that leads to useful results on your evaluation examples. Note that you are using a model here that is different from your SLM and also you are training the model using LoRA instead of performing full-parameter fine-tuning. Therefore, the optimal hyperparameters may be different for fine-tuning the Gemma model than the ones you used to fine-tune your SLM.\n",
+    "\n",
+    "For pre-trained models like Gemma, a reasonable range for the number of epochs is usually 1 to 20, depending both on the size of your fine-tuning set and the learning rate. If you use a larger fine-tuning set and/or a higher learning rate, you generally need to fine-tune for fewer epochs. Conversely, if you have very few fine-tuning examples or use a very low learning rate, you will need to fine-tune for more epochs.\n",
+    "\n",
+    "For the learning rate, values between 0.0001 (1e-4) and 0.000001 (1e-6) tend to work well in practice for fine-tuning models like Gemma.\n",
+    "\n",
+    "<br>\n",
+    "\n",
+    "------\n",
+    "> **💻 Your task:**\n",
+    ">\n",
+    "> Find the right setting for the learning rate.\n",
+    ">\n",
+    "> In practice, you would fine-tune a model multiple times with different learning rates and evaluate the model performance during fine-tuning. You would then choose a learning rate that leads to the best evaluation results. However, since fine-tuning consumes a lot of GPU resources and your Colab GPU resources may be limited, the following cell provides you with the output of training runs with different learning rates.\n",
+    ">\n",
+    "> Select a learning rate and execute the cell to print the log of the training run with that specific learning rate. Look at the model generations after each epoch and choose a learning rate that leads to \"good\" results for all prompts.\n",
+    ">\n",
+    "------"
+   ],
+   "metadata": {
+    "id": "Bzfd9R-dAy0Z"
+   }
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "# @title Training logs for different learning rates\n",
+    "\n",
+    "if \"training_logs\" not in globals():\n",
+    "    TRAINING_LOG_URL = \"https://storage.googleapis.com/dm-educational/assets/ai_foundations/finetune-gemma-training-logs.json\"\n",
+    "    with request.urlopen(TRAINING_LOG_URL) as json_file:\n",
+    "        training_logs = json.loads(json_file.read().decode())\n",
+    "\n",
+    "learning_rate = 1e-3 # @param [\"1e-3\",\"5e-4\",\"2e-4\",\"1e-4\",\"5e-5\",\"2e-5\",\"1e-5\",\"5e-6\",\"2e-6\",\"1e-6\"] {\"type\":\"raw\"}\n",
+    "\n",
+    "print(training_logs[str(learning_rate)])"
+   ],
+   "metadata": {
+    "id": "RiXiy6QkRxj1",
+    "cellView": "form"
+   },
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Once you have determined the optimal learning rate for this fine-tuning problem, add the learning rate to the following cell."
+   ],
+   "metadata": {
+    "id": "8_uspPwH8w8N"
+   }
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "# Set the learning rate\n",
+    "model.optimizer.learning_rate = # Add your code here.\n",
+    "\n",
+    "# Set the number of epochs.\n",
+    "num_epochs = 10\n",
+    "\n",
+    "# Set the maximum length.\n",
+    "model.preprocessor.sequence_length = 400"
+   ],
+   "metadata": {
+    "id": "5P2iEx7piCzV"
+   },
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Perform fine-tuning\n",
+    "\n",
+    "Now that you have prepared the data and set up the model and LoRA, fine-tuning can be done just like any other training in Keras, that is, with the `model.fit()` method.\n",
+    "\n",
+    "As previously, it is important to monitor the training progress using a callback function. Run the following cell to define a callback function that prints generations for the three evaluation prompts that you defined above.\n",
+    "\n"
+   ],
+   "metadata": {
+    "id": "eXSVDVgombdA"
+   }
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "class EvaluationCallback(keras.callbacks.Callback):\n",
+    "    \"\"\"\n",
+    "    A Keras callback function to print generations for evaluation prompts.\n",
+    "    \"\"\"\n",
+    "    def on_epoch_end(self, epoch: int, logs=None):\n",
+    "        \"\"\"Prints generations for the three evaluation prompts.\n",
+    "\n",
+    "        Args:\n",
+    "          epoch: The current epoch.\n",
+    "          logs: The logs dictionary.\n",
+    "        \"\"\"\n",
+    "\n",
+    "        evaluation_prompts = [\n",
+    "            \"What is Kente cloth?\",\n",
+    "            \"What is the tallest mountain in Africa?\",\n",
+    "            \"What is Mount Aconcagua?\"\n",
+    "        ]\n",
+    "\n",
+    "        # Run three formatted questions through the model.\n",
+    "        # Generate answers with a length of (up to) 200 tokens.\n",
+    "        for prompt in evaluation_prompts:\n",
+    "            formatted_prompt = format_question(prompt)\n",
+    "            model_response = model.generate(formatted_prompt, max_length=200)\n",
+    "            print(fill(model_response, replace_whitespace=False))\n",
+    "            print('\\n------\\n')\n",
+    "\n",
+    "evaluation_callback = EvaluationCallback()"
+   ],
+   "metadata": {
+    "id": "VI_d54GPAhmH"
+   },
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "------\n",
+    "> **💻 Your task:**\n",
+    ">\n",
+    ">Run the following cell to fine-tune your model.\n",
+    ">\n",
+    ">While the model is fine-tuning, monitor the fine-tuning progress using the three evaluation prompts.\n",
+    ">\n",
+    ">Keep note of:\n",
+    ">\n",
+    ">* When does the model begin to output \"\\<start_of_turn>model\"?\n",
+    ">* When does the model begin to produce outputs that start with \"Category:\" and the correct category?\n",
+    ">* At which epochs does the model produce very strange outputs?\n",
+    ">* From which epoch on does the model consistently produce a single paragraph and stop repeating texts?\n",
+    ">* At which epoch does the model start to produce \"\\<end_of_turn>\" and stop producing any other output thereafter?\n",
+    ">\n",
+    ">After the first epoch, the training will take about one to two minutes per epoch on a T4 GPU.  Expect that it takes 15 to 20 minutes in total for fine-tuning the model for 10 epochs.\n",
+    ">\n",
+    "------"
+   ],
+   "metadata": {
+    "id": "yjOQCTGTAg9O"
+   }
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "training_history = model.fit(\n",
+    "    data,\n",
+    "    epochs=num_epochs,\n",
+    "    batch_size=1,\n",
+    "    verbose=1,\n",
+    "    callbacks=[evaluation_callback]\n",
+    ")"
+   ],
+   "metadata": {
+    "id": "VuAIS6BJMplA"
+   },
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "\n",
+    "At the end of the fine-tuning process, did the model outputs satisfy all of the criteria mentioned above? If not, you may want to continue fine-tuning for a few more epochs.\n",
+    "\n",
+    "Overall, you likely noticed \"good\" performance, even for questions that are not about African culture and geography. For example, the question about the South American Mountain, \"What is Mount Aconcagua?\". You likely observed that the pre-trained model was able to provide an answer about this mountain and managed to do so in the desired format for the flashcard generator. In doing so, it managed to combine the factual information from its pre-training performed on a dataset of 2 trillion tokens with the specifics of the format that it learned from the fine-tuning examples."
+   ],
+   "metadata": {
+    "id": "j8ufZC7uqo-z"
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Additional evaluations\n",
+    "\n",
+    "As always, it is important to test your model on a wide range of questions. Define some more questions below and check the model outputs."
+   ],
+   "metadata": {
+    "id": "YcrLDX9lvE00"
+   }
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "additional_prompts = [\n",
+    "    \"What is Mount Aconcagua?\",\n",
+    "    \"What is American Football?\",\n",
+    "    \"What is Python?\"\n",
+    "]\n",
+    "\n",
+    "for prompt in additional_prompts:\n",
+    "    formatted_prompt = format_question(prompt)\n",
+    "    model_response = model.generate(formatted_prompt, max_length=300)\n",
+    "    print(fill(model_response, replace_whitespace=False))\n",
+    "    print('\\n------\\n')"
+   ],
+   "metadata": {
+    "id": "UCTmTb4ECLWo"
+   },
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "#### What did you observe?\n",
+    "\n",
+    "You likely observed that the model was able to infer appropriate categories for many questions and managed to output many reasonable responses.\n",
+    "\n",
+    "If the responses to all your questions were useful, try to find very niche topics and ask the model about them. Are you able to find the limits of this model?\n"
+   ],
+   "metadata": {
+    "id": "OJONdeXQIgIB"
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Summary\n",
+    "\n",
+    "In this lab you fine-tuned Gemma-1B with LoRA. You observed that the model could not only produce answers in the desired format for the topics that are present in the fine-tuning dataset (Africa Galore QA) but on a variety of topics.\n",
+    "\n",
+    "This process demonstrated the power of combining \"good\" pre-trained models with fine-tuning. It allows you to build highly capable models for many tasks with a small fine-tuning dataset."
+   ],
+   "metadata": {
+    "id": "zfbLYukJzVgA"
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Solutions\n",
+    "\n",
+    "The following cells provide reference solutions to the coding activities in this notebook. If you really get stuck after trying to solve the activities yourself, you may want to consult these solutions.\n",
+    "\n",
+    "It is recommended that you *only* look at the solutions after you have tried to solve the activities *multiple times*. The best way to learn challenging concepts in computer science and artificial intelligence is to debug your code piece-by-piece until it works, rather than copying existing solutions.\n",
+    "\n",
+    "If you feel stuck, you may want to first try to debug your code. For example, by adding additional print statements to see what your code is doing at every step. This will provide you with a much deeper understanding of the code and the materials. It will also provide you with practice on how to solve challenging coding problems beyond this course.\n",
+    "\n",
+    "To view the solutions for an activity, click the arrow to the left of the activity name. If you consult the solutions, do not copy and paste them into the cells above. Instead, look at them, and type them manually into the cell. This will help you understand where you went wrong.\n"
+   ],
+   "metadata": {
+    "id": "eMHZ2_UicETN"
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Activity 1"
+   ],
+   "metadata": {
+    "id": "1htAIUJxcSB0"
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "A good choice for the learning rate is 2e-5. With this setting, the answers stabilize after about 7 to 8 epochs and are factually correct.\n",
+    "\n",
+    "A lower learning rate is also possible. However, the lower the learning rate you choose, the more epochs you need for fine-tuning.\n",
+    "\n",
+    "Higher learning rates look good at first glance but the answers are of lower quality.\n",
+    "\n",
+    "The answers produced by a learning rate of 5e-5 do not mention that Tokyo is the capital city of Japan and give a more generic description that applies to very large cities in general. That being said, they may still be acceptable.\n",
+    "\n",
+    "A learning rate of 1e-4 leads to answers that contain factual errors. For example, Kilimanjaro is not the second highest peak in the world after Mount Everest. Kilimanjaro is known for many amazing facts, but not that it played a particular role in a 1952 ascent of Mount Everest. The first successful climb of Mount Everest happened one year later. Even higher learning rates have similar problems.\n",
+    "\n",
+    "As you will observe, it can be quite difficult to judge the correctness of answers. The \"destruction\" of pre-trained knowledge with higher learning rates can be difficult to spot. Catastrophic forgetting does not necessarily occur on all aspects but can be more subtle as for the Kilimanjaro answers for a learning rate of 1e-4. Therefore, it is important to choose validation prompts that you yourself can answer very well at expert level."
+   ],
+   "metadata": {
+    "id": "H7vm7kxkcWHj"
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## References\n",
+    "\n",
+    "[1] Gemma Team, Google DeepMind. 2025. Gemma 3 technical report. https://arxiv.org/pdf/2503.19786\n",
+    "\n",
+    "[2] Edward Hu, Yelong Shen, Phillip Wallis, Zeyuan Allen-Zhu, Yuanzhi Li, Shean Wang, Lu Wang, and Weizhu Chen. 2022. LoRA: Low-rank adaptation of large language models. In *International Conference on Learning Representations (ICLR 2022)*. https://openreview.net/pdf?id=nZeVKeeFYf9\n",
+    "\n",
+    "[3] Dan Biderman, Jacob Portes, Jose Javier Gonzalez Ortiz, Mansheej Paul, Philip Greengard, Connor Jennings, Daniel King, Sam Havens, Vitaliy Chiley, Jonathan Frankle, Cody Blakeney, and John P. Cunningham. 2024. LoRA learns less and forgets less. *Transactions on Machine Learning Research*. https://openreview.net/forum?id=aloEru2qCG\n"
+   ],
+   "metadata": {
+    "id": "xF7JKexDcqvs"
+   }
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "collapsed_sections": [
+    "NDWsJUGcf4Ru",
+    "eMHZ2_UicETN",
+    "1htAIUJxcSB0"
+   ],
+   "provenance": [],
+   "gpuType": "T4"
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  },
+  "accelerator": "GPU"
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
 }


### PR DESCRIPTION
## Summary
- Fixes #17: Replace legacy `KAGGLE_USERNAME`/`KAGGLE_KEY` authentication with the current `KAGGLE_API_TOKEN` method in Labs 5.4 and 5.6.
- Updated markdown instructions (Steps 3 & 4) to guide students through generating and storing a single API token instead of extracting two values from a `kaggle.json` file.
- Updated code cells to set `KAGGLE_API_TOKEN` environment variable instead of `KAGGLE_USERNAME` and `KAGGLE_KEY`.

## Test plan
- [ ] Open Lab 5.4 in Colab, verify the "Set up a Kaggle account" instructions are clear and reference the correct Kaggle UI elements
- [ ] Open Lab 5.6 in Colab, verify the same
- [ ] Set `KAGGLE_API_TOKEN` as a Colab secret and confirm `keras_nlp.models.Gemma3CausalLM.from_preset("gemma3_1b")` downloads the model successfully