### PR TITLE
Update Course 7 notebooks to use current Kaggle API token auth

### DIFF
--- a/course_7/gdm_lab_7_3_hitting_a_wall.ipynb
+++ b/course_7/gdm_lab_7_3_hitting_a_wall.ipynb
@@ -1,437 +1,355 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "provenance": [],
-      "collapsed_sections": [
-        "NDWsJUGcf4Ru",
-        "n6-dSJ-o_JT9"
-      ],
-      "gpuType": "T4"
-    },
-    "kernelspec": {
-      "name": "python3",
-      "display_name": "Python 3"
-    },
-    "language_info": {
-      "name": "python"
-    },
-    "accelerator": "GPU"
+ "nbformat": 4,
+ "nbformat_minor": 0,
+ "metadata": {
+  "colab": {
+   "provenance": [],
+   "collapsed_sections": [
+    "NDWsJUGcf4Ru",
+    "n6-dSJ-o_JT9"
+   ],
+   "gpuType": "T4"
   },
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "source": [
-        "<img src=\"https://storage.googleapis.com/dm-educational/assets/ai_foundations/GDM-Labs-banner-image-C6-white-bg.png\">"
-      ],
-      "metadata": {
-        "id": "O6E5AAk2l8c-"
-      }
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "# Lab: Hitting a Wall\n",
-        "\n",
-        "<a href='https://colab.research.google.com/github/google-deepmind/ai-foundations/blob/master/course_7/gdm_lab_7_3_hitting_a_wall.ipynb' target='_parent'><img src='https://colab.research.google.com/assets/colab-badge.svg' alt='Open In Colab'/></a>\n",
-        "\n",
-        "Investigate the hardware limitations of training large models and experience first-hand out-of-memory errors.\n",
-        "\n",
-        "15 minutes"
-      ],
-      "metadata": {
-        "id": "5cNGZ1qSl9Sp"
-      }
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "## Overview\n",
-        "\n",
-        "Earlier in this course, you saw that larger models like Gemma-4B can produce higher-quality generations than smaller models like Gemma-1B. What would it take to fine-tune a large model like Gemma-4B yourself?\n",
-        "\n",
-        "In the previous course, you successfully fine-tuned Gemma-1B using LoRA. In this lab, you will attempt to apply the same fine-tuning process to the larger Gemma-4B model. This exercise is designed to give you a first-hand experience of the \"memory wall\". This describes a critical hardware limitation, which, as you will observe, motivates the need for the efficiency techniques you are learning in this course."
-      ],
-      "metadata": {
-        "id": "4_3eiCnvptt2"
-      }
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "### What you will learn\n",
-        "\n",
-        "By the end of this lab, you will be able to:\n",
-        "\n",
-        "* Describe why even with LoRA you cannot fine-tune bigger models.\n",
-        "\n",
-        "* The motivation for using memory-saving techniques."
-      ],
-      "metadata": {
-        "id": "hz1L39mgrBuc"
-      }
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "## Tasks\n"
-      ],
-      "metadata": {
-        "id": "RBrY9KVfrPV3"
-      }
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "**In this lab, you will**:\n",
-        "\n",
-        "* Attempt to fine-tune the base Gemma-4B model.\n",
-        "\n",
-        "* Encounter and reflect on the resulting out-of-memory (OOM) error.\n",
-        "\n",
-        " **This lab needs to be run on a GPU. Choose a T4 GPU.** See the section \"How to use Google Colaboratory (Colab)\" below for instructions on how to do this.\n",
-        "\n",
-        " **You also need a Kaggle account** to download the weights of the Gemma 3 model. See the section \"Set up a Kaggle account\" for instructions on how to do this.\n"
-      ],
-      "metadata": {
-        "id": "_PE2ozNbrYvy"
-      }
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "NDWsJUGcf4Ru"
-      },
-      "source": [
-        "## How to use Google Colaboratory (Colab)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "wlNG_jg-39Zj"
-      },
-      "source": [
-        "Google Colaboratory (also known as Google Colab) is a platform that allows you to run Python code in your browser. The code is written in **cells** that are excuted on a remote server.\n",
-        "\n",
-        "To run a cell, hover over a cell and click on the `run` button to its left. The run button is the circle with the triangle (▶). Alternatively, you can also click on a cell and use the keyboard combination Ctrl+Return (or ⌘+Return if you are using a Mac).\n",
-        "\n",
-        "To try this out, run the following cell. This should print today's day of the week below it."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "UyTT6C0JhGBs"
-      },
-      "outputs": [],
-      "source": [
-        "from datetime import datetime\n",
-        "print(f\"Today is {datetime.today():%A}.\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "pbtgZxrpjm6j"
-      },
-      "source": [
-        "Note that the **order in which you run the cells matters**. When you are working through a lab, make sure to always run all cells in order, otherwise the code might not work. If you take a break while working on a lab, Colab may disconnect you and in that case, you have to execute all cells again before  continuing your work. To make this easier, you can select the cell you are currently working on and then choose _Runtime → Run before_  from the menu above (or use the keyboard combination Ctrl/⌘ + F8). This will re-execute all cells before the current one."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "### Using Colab with a GPU\n",
-        "\n",
-        "Follow these steps to run the activities in this lab on a GPU:\n",
-        "\n",
-        "1.  In the top menu bar, click on **Runtime**.\n",
-        "2.  Select **Change runtime type** from the dropdown menu.\n",
-        "3.  In the pop-up window under **Hardware accelerator**, select **T4 GPU**.\n",
-        "4.  Click **Save**.\n",
-        "\n",
-        "Your Colab session will now restart with GPU access.\n",
-        "\n",
-        "Note that access to GPUs is limited and at times, you may not be able to run this lab on a GPU. All activities will still work but they will run slower and you will have to wait longer for some of the cells to finish running."
-      ],
-      "metadata": {
-        "id": "kN3yE5jSg9zH"
-      }
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "## Set up a Kaggle account\n"
-      ],
-      "metadata": {
-        "id": "n6-dSJ-o_JT9"
-      }
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "\n",
-        "To run this notebook, you will have to sign up for [Kaggle](https://www.kaggle.com), a platform that hosts datasets and models for machine learning. You will also need to sign the agreement for using the Gemma 3 model. This is required so that you can download the weights of the Gemma model for fine-tuning.\n",
-        "\n",
-        "### Step 1: Create your Kaggle account\n",
-        "\n",
-        "* Go to the Kaggle website: https://www.kaggle.com\n",
-        "\n",
-        "* Click the \"Register\" button in the top-right corner.\n",
-        "\n",
-        "* You can sign up using your Google account (recommended for easy Colab integration) or by entering an email and password.\n",
-        "\n",
-        "* Follow the on-screen prompts to complete your registration and verify your email.\n",
-        "\n",
-        "### Step 2: Sign the Gemma 3 model agreement\n",
-        "\n",
-        "* Make sure you are logged into your new Kaggle account.\n",
-        "\n",
-        "* Go directly to the Gemma 3 model card page: https://www.kaggle.com/models/keras/gemma3/keras/\n",
-        "\n",
-        "* You should see a \"Request Access\" button.\n",
-        "\n",
-        "* Click the button, read through the license agreement, and if you are happy with the terms click \"Accept\" to gain access to the model. You must do this before the API will let you download the model.\n",
-        "\n",
-        "### Step 3: Generate your Kaggle API key\n",
-        "\n",
-        "* From any Kaggle page, click on your profile picture or icon in the top-right corner.\n",
-        "\n",
-        "* Select \"Account\" from the drop-down menu.\n",
-        "\n",
-        "* Scroll down to the \"API\" section.\n",
-        "\n",
-        "* Click the \"Create New API Token\" button.\n",
-        "\n",
-        "* This will immediately download a file named `kaggle.json` to your computer. This file contains your username and your secret API key. Keep it safe.\n",
-        "\n",
-        "### Step 4: Set your API Key in  Colab\n",
-        "\n",
-        "* Click the \"key\" icon 🔑 in the left-hand sidebar.\n",
-        "\n",
-        "* You will see the \"Secrets\" panel.\n",
-        "\n",
-        "* Now, open the kaggle.json file you downloaded on your computer. It is a simple text file and will look like this:\n",
-        "\n",
-        "   ```json\n",
-        "   {\"username\":\"YOUR_KAGGLE_USERNAME\",\"key\":\"YOUR_KAGGLE_API_KEY\"}\n",
-        "   ```\n",
-        "* In the Colab Secrets panel, create two new secrets:\n",
-        "\n",
-        "   1. Name: `KAGGLE_USERNAME`\n",
-        "\n",
-        "      Value: Copy and paste `YOUR_KAGGLE_USERNAME` from your `kaggle.json` file.\n",
-        "\n",
-        "   2. Name: `KAGGLE_KEY`\n",
-        "\n",
-        "      Value: Copy and paste `YOUR_KAGGLE_API_KEY` from your `kaggle.json` file.\n",
-        "\n",
-        "* For both secrets, make sure the \"Notebook access\" toggle is switched on.\n"
-      ],
-      "metadata": {
-        "id": "9iS70YEC_Hx8"
-      }
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "## Imports\n",
-        "\n",
-        "In this lab, you will use the Keras package for loading a Gemma model and the Pandas package, for loading the dataset.\n",
-        "\n",
-        "Run the following cell to import the required packages.\n",
-        "\n"
-      ],
-      "metadata": {
-        "id": "ynNQ7wwks3v3"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "%%capture\n",
-        "# Install the custom package for this course.\n",
-        "!pip install \"git+https://github.com/google-deepmind/ai-foundations.git@main\"\n",
-        "\n",
-        "import os # For setting system variables.\n",
-        "\n",
-        "from google.colab import userdata # For using Colab secrets.\n",
-        "\n",
-        "os.environ[\"KAGGLE_USERNAME\"] = userdata.get(\"KAGGLE_USERNAME\")\n",
-        "os.environ[\"KAGGLE_KEY\"] = userdata.get(\"KAGGLE_KEY\")\n",
-        "\n",
-        "os.environ[\"KERAS_BACKEND\"] = \"jax\"  # Set the Keras backend to JAX.\n",
-        "# Disables the command buffer pre-allocation to free up memory.\n",
-        "os.environ[\"XLA_FLAGS\"] = \"--xla_gpu_enable_command_buffer=\"\n",
-        "os.environ[\"XLA_PYTHON_CLIENT_MEM_FRACTION\"]=\"0.9\"\n",
-        "\n",
-        "import keras # For defining and training models.\n",
-        "import keras_nlp # For loading the Keras implementation of Gemma.\n",
-        "import pandas as pd # For loading the dataset.\n",
-        "from textwrap import fill # For formatting long paragraphs.\n",
-        "from ai_foundations import formatting # For formatting the training data.\n",
-        "\n",
-        "keras.utils.set_random_seed(812)  # For Keras layers."
-      ],
-      "metadata": {
-        "id": "TfUQTROPs-a4"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "## Fine-tune Gemma-4B\n",
-        "\n",
-        "In the previous course, you learned to fine-tune Gemma-1B using LoRA for building a revison study flashcard generator. In this lab, you will apply the same fine-tuning techniques to fine-tune Gemma-4B.\n",
-        "\n",
-        "Run the following cell to:\n",
-        "\n",
-        "* Define the `format_question` function to format model inputs.\n",
-        "* Prepare the Africa Galore dataset for fine-tuning."
-      ],
-      "metadata": {
-        "id": "y7WNKIVWs1Wc"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "def format_question(\n",
-        "    question: str,\n",
-        "    sot = \"<start_of_turn>\",\n",
-        "    eot = \"<end_of_turn>\"\n",
-        ") -> str:\n",
-        "    \"\"\"\n",
-        "    Formats a question for prompting the model and adds special delimiters at\n",
-        "    the start and end of the question.\n",
-        "\n",
-        "    Args:\n",
-        "      text: The question to be formatted.\n",
-        "      sot: The token to mark the start of a turn.\n",
-        "      eot: The token to mark the end of a turn.\n",
-        "\n",
-        "    Returns:\n",
-        "      Formatted string of the question.\n",
-        "    \"\"\"\n",
-        "\n",
-        "    formatted_q = f\"{sot}user\\n{question}{eot}\\n\"\n",
-        "\n",
-        "    return formatted_q\n",
-        "\n",
-        "# Load the question-answer dataset.\n",
-        "africa_galore_qa = pd.read_json(\n",
-        "    \"https://storage.googleapis.com/dm-educational/assets/ai_foundations/africa_galore_qa_v2.json\"\n",
-        ")\n",
-        "\n",
-        "questions = []  # List of formatted questions.\n",
-        "answers = []  # List of formatted answers.\n",
-        "\n",
-        "for idx, row in africa_galore_qa.iterrows():\n",
-        "    # Run the format_qa function from the previous lab to format the question\n",
-        "    # and the answer.\n",
-        "    question, answer = formatting.format_qa(row)\n",
-        "    questions.append(question)\n",
-        "    answers.append(answer)\n",
-        "\n",
-        "# Show the first set of input and output.\n",
-        "print(questions[0])\n",
-        "print(fill(answers[0], replace_whitespace=False))\n",
-        "\n",
-        "# Prepare the data dictionary for fine-tuning Gemma.\n",
-        "data = {\n",
-        "    \"prompts\": questions,\n",
-        "    \"responses\": answers\n",
-        "}"
-      ],
-      "metadata": {
-        "id": "Chd0kZqPtNAT"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "## Activity 1: Load Gemma-4B\n",
-        "\n",
-        "------\n",
-        "> 💻 **Your task**:\n",
-        ">\n",
-        "> Run the next cell to load in the base Gemma-4B model with full 32-bit precision, where all numbers are represented as 32bit floating point numbers.\n",
-        ">\n",
-        "> Does the cell run successfully? Reflect on the output and why this might be happening.\n",
-        ">\n",
-        "------"
-      ],
-      "metadata": {
-        "id": "PT2eWi4Wtyx-"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "# Load the Gemma3-4B Keras model.\n",
-        "model = keras_nlp.models.Gemma3CausalLM.from_preset(preset=\"gemma3_4b_text\")\n",
-        "model.summary()"
-      ],
-      "metadata": {
-        "id": "hN_7KvaXt-8I"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "### What did you observe?\n",
-        "\n",
-        "You should have encountered an error saying `RESOURCE_EXHAUSTED` as well a message indicating how much memory the process attempted to allocate.\n",
-        "\n",
-        "------\n",
-        "> **💭 Reflection:**\n",
-        ">\n",
-        ">Given this output, briefly reflect on these questions:\n",
-        ">\n",
-        ">1. What do you think the error means at a high level?\n",
-        ">\n",
-        ">2. Based on what you have read so far about GPU memory consumers, write down a hypothesis for why this happens.\n",
-        ">\n",
-        "------"
-      ],
-      "metadata": {
-        "id": "H_MfGYCx4m5p"
-      }
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "### Out-of-memory errors\n",
-        "\n",
-        "The `RESOURCE_EXHAUSTED` error is the technical name for an out-of-memory (OOM) error. It means that the GPU ran out of memory while trying to load the model.\n",
-        "\n",
-        "This error highlights that for a model of this size, you cannot even load the model with standard settings. However, this issue is not insurmountable. It is the exact problem that modern efficiency techniques are designed to solve. In the next article, you will learn what takes up so much memory in the GPU. Later on, you will also observe how using techniques like mixed precision can help you to overcome this memory wall.\n",
-        "\n",
-        "In case you are wondering why it was possible to load the Gemma-4B model in the first lab of this course, note that that lab already used some memory efficiency techniques in the background."
-      ],
-      "metadata": {
-        "id": "snEknum9TIkN"
-      }
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "## Summary\n",
-        "\n",
-        "This lab provided a practical demonstration of the hardware limitations involved in training large models. You experienced what it is like to hit the \"memory wall\" again. You further observed that when attempting to fine-tune a large model, it can fail with an out-of-memory error even at the point of loading the parameter weights. In the next activity, you will learn more about the main components that consume of GPU memory."
-      ],
-      "metadata": {
-        "id": "mtPvGi_97gcS"
-      }
-    }
-  ]
+  "kernelspec": {
+   "name": "python3",
+   "display_name": "Python 3"
+  },
+  "language_info": {
+   "name": "python"
+  },
+  "accelerator": "GPU"
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "source": [
+    "<img src=\"https://storage.googleapis.com/dm-educational/assets/ai_foundations/GDM-Labs-banner-image-C6-white-bg.png\">"
+   ],
+   "metadata": {
+    "id": "O6E5AAk2l8c-"
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "# Lab: Hitting a Wall\n",
+    "\n",
+    "<a href='https://colab.research.google.com/github/google-deepmind/ai-foundations/blob/master/course_7/gdm_lab_7_3_hitting_a_wall.ipynb' target='_parent'><img src='https://colab.research.google.com/assets/colab-badge.svg' alt='Open In Colab'/></a>\n",
+    "\n",
+    "Investigate the hardware limitations of training large models and experience first-hand out-of-memory errors.\n",
+    "\n",
+    "15 minutes"
+   ],
+   "metadata": {
+    "id": "5cNGZ1qSl9Sp"
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Overview\n",
+    "\n",
+    "Earlier in this course, you saw that larger models like Gemma-4B can produce higher-quality generations than smaller models like Gemma-1B. What would it take to fine-tune a large model like Gemma-4B yourself?\n",
+    "\n",
+    "In the previous course, you successfully fine-tuned Gemma-1B using LoRA. In this lab, you will attempt to apply the same fine-tuning process to the larger Gemma-4B model. This exercise is designed to give you a first-hand experience of the \"memory wall\". This describes a critical hardware limitation, which, as you will observe, motivates the need for the efficiency techniques you are learning in this course."
+   ],
+   "metadata": {
+    "id": "4_3eiCnvptt2"
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### What you will learn\n",
+    "\n",
+    "By the end of this lab, you will be able to:\n",
+    "\n",
+    "* Describe why even with LoRA you cannot fine-tune bigger models.\n",
+    "\n",
+    "* The motivation for using memory-saving techniques."
+   ],
+   "metadata": {
+    "id": "hz1L39mgrBuc"
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Tasks\n"
+   ],
+   "metadata": {
+    "id": "RBrY9KVfrPV3"
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "**In this lab, you will**:\n",
+    "\n",
+    "* Attempt to fine-tune the base Gemma-4B model.\n",
+    "\n",
+    "* Encounter and reflect on the resulting out-of-memory (OOM) error.\n",
+    "\n",
+    " **This lab needs to be run on a GPU. Choose a T4 GPU.** See the section \"How to use Google Colaboratory (Colab)\" below for instructions on how to do this.\n",
+    "\n",
+    " **You also need a Kaggle account** to download the weights of the Gemma 3 model. See the section \"Set up a Kaggle account\" for instructions on how to do this.\n"
+   ],
+   "metadata": {
+    "id": "_PE2ozNbrYvy"
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "NDWsJUGcf4Ru"
+   },
+   "source": [
+    "## How to use Google Colaboratory (Colab)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "wlNG_jg-39Zj"
+   },
+   "source": [
+    "Google Colaboratory (also known as Google Colab) is a platform that allows you to run Python code in your browser. The code is written in **cells** that are excuted on a remote server.\n",
+    "\n",
+    "To run a cell, hover over a cell and click on the `run` button to its left. The run button is the circle with the triangle (▶). Alternatively, you can also click on a cell and use the keyboard combination Ctrl+Return (or ⌘+Return if you are using a Mac).\n",
+    "\n",
+    "To try this out, run the following cell. This should print today's day of the week below it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "UyTT6C0JhGBs"
+   },
+   "outputs": [],
+   "source": [
+    "from datetime import datetime\n",
+    "print(f\"Today is {datetime.today():%A}.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "pbtgZxrpjm6j"
+   },
+   "source": [
+    "Note that the **order in which you run the cells matters**. When you are working through a lab, make sure to always run all cells in order, otherwise the code might not work. If you take a break while working on a lab, Colab may disconnect you and in that case, you have to execute all cells again before  continuing your work. To make this easier, you can select the cell you are currently working on and then choose _Runtime → Run before_  from the menu above (or use the keyboard combination Ctrl/⌘ + F8). This will re-execute all cells before the current one."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Using Colab with a GPU\n",
+    "\n",
+    "Follow these steps to run the activities in this lab on a GPU:\n",
+    "\n",
+    "1.  In the top menu bar, click on **Runtime**.\n",
+    "2.  Select **Change runtime type** from the dropdown menu.\n",
+    "3.  In the pop-up window under **Hardware accelerator**, select **T4 GPU**.\n",
+    "4.  Click **Save**.\n",
+    "\n",
+    "Your Colab session will now restart with GPU access.\n",
+    "\n",
+    "Note that access to GPUs is limited and at times, you may not be able to run this lab on a GPU. All activities will still work but they will run slower and you will have to wait longer for some of the cells to finish running."
+   ],
+   "metadata": {
+    "id": "kN3yE5jSg9zH"
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Set up a Kaggle account\n"
+   ],
+   "metadata": {
+    "id": "n6-dSJ-o_JT9"
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": "\nTo run this notebook, you will have to sign up for [Kaggle](https://www.kaggle.com), a platform that hosts datasets and models for machine learning. You will also need to sign the agreement for using the Gemma 3 model. This is required so that you can download the weights of the Gemma model for fine-tuning.\n\n### Step 1: Create your Kaggle account\n\n* Go to the Kaggle website: https://www.kaggle.com\n\n* Click the \"Register\" button in the top-right corner.\n\n* You can sign up using your Google account (recommended for easy Colab integration) or by entering an email and password.\n\n* Follow the on-screen prompts to complete your registration and verify your email.\n\n### Step 2: Sign the Gemma 3 model agreement\n\n* Make sure you are logged into your new Kaggle account.\n\n* Go directly to the Gemma 3 model card page: https://www.kaggle.com/models/keras/gemma3/keras/\n\n* You should see a \"Request Access\" button.\n\n* Click the button, read through the license agreement, and if you are happy with the terms click \"Accept\" to gain access to the model. You must do this before the API will let you download the model.\n\n### Step 3: Generate your Kaggle API token\n\n* From any Kaggle page, click on your profile picture or icon in the top-right corner.\n\n* Select \"Settings\" from the drop-down menu.\n\n* Scroll down to the \"API\" section.\n\n* Click the \"Generate New Token\" button.\n\n* Copy the token value that is displayed.\n\n### Step 4: Set your API token in Colab\n\n* Click the \"key\" icon 🔑 in the left-hand sidebar.\n\n* You will see the \"Secrets\" panel.\n\n* In the Colab Secrets panel, create a new secret:\n\n   * Name: `KAGGLE_API_TOKEN`\n\n   * Value: Paste the token you copied in Step 3.\n\n* Make sure the \"Notebook access\" toggle is switched on.",
+   "metadata": {
+    "id": "9iS70YEC_Hx8"
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Imports\n",
+    "\n",
+    "In this lab, you will use the Keras package for loading a Gemma model and the Pandas package, for loading the dataset.\n",
+    "\n",
+    "Run the following cell to import the required packages.\n",
+    "\n"
+   ],
+   "metadata": {
+    "id": "ynNQ7wwks3v3"
+   }
+  },
+  {
+   "cell_type": "code",
+   "source": "%%capture\n# Install the custom package for this course.\n!pip install \"git+https://github.com/google-deepmind/ai-foundations.git@main\"\n\nimport os # For setting system variables.\n\nfrom google.colab import userdata # For using Colab secrets.\n\nos.environ[\"KAGGLE_API_TOKEN\"] = userdata.get(\"KAGGLE_API_TOKEN\")\n\nos.environ[\"KERAS_BACKEND\"] = \"jax\"  # Set the Keras backend to JAX.\n# Disables the command buffer pre-allocation to free up memory.\nos.environ[\"XLA_FLAGS\"] = \"--xla_gpu_enable_command_buffer=\"\nos.environ[\"XLA_PYTHON_CLIENT_MEM_FRACTION\"]=\"0.9\"\n\nimport keras # For defining and training models.\nimport keras_nlp # For loading the Keras implementation of Gemma.\nimport pandas as pd # For loading the dataset.\nfrom textwrap import fill # For formatting long paragraphs.\nfrom ai_foundations import formatting # For formatting the training data.\n\nkeras.utils.set_random_seed(812)  # For Keras layers.",
+   "metadata": {
+    "id": "TfUQTROPs-a4"
+   },
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Fine-tune Gemma-4B\n",
+    "\n",
+    "In the previous course, you learned to fine-tune Gemma-1B using LoRA for building a revison study flashcard generator. In this lab, you will apply the same fine-tuning techniques to fine-tune Gemma-4B.\n",
+    "\n",
+    "Run the following cell to:\n",
+    "\n",
+    "* Define the `format_question` function to format model inputs.\n",
+    "* Prepare the Africa Galore dataset for fine-tuning."
+   ],
+   "metadata": {
+    "id": "y7WNKIVWs1Wc"
+   }
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "def format_question(\n",
+    "    question: str,\n",
+    "    sot = \"<start_of_turn>\",\n",
+    "    eot = \"<end_of_turn>\"\n",
+    ") -> str:\n",
+    "    \"\"\"\n",
+    "    Formats a question for prompting the model and adds special delimiters at\n",
+    "    the start and end of the question.\n",
+    "\n",
+    "    Args:\n",
+    "      text: The question to be formatted.\n",
+    "      sot: The token to mark the start of a turn.\n",
+    "      eot: The token to mark the end of a turn.\n",
+    "\n",
+    "    Returns:\n",
+    "      Formatted string of the question.\n",
+    "    \"\"\"\n",
+    "\n",
+    "    formatted_q = f\"{sot}user\\n{question}{eot}\\n\"\n",
+    "\n",
+    "    return formatted_q\n",
+    "\n",
+    "# Load the question-answer dataset.\n",
+    "africa_galore_qa = pd.read_json(\n",
+    "    \"https://storage.googleapis.com/dm-educational/assets/ai_foundations/africa_galore_qa_v2.json\"\n",
+    ")\n",
+    "\n",
+    "questions = []  # List of formatted questions.\n",
+    "answers = []  # List of formatted answers.\n",
+    "\n",
+    "for idx, row in africa_galore_qa.iterrows():\n",
+    "    # Run the format_qa function from the previous lab to format the question\n",
+    "    # and the answer.\n",
+    "    question, answer = formatting.format_qa(row)\n",
+    "    questions.append(question)\n",
+    "    answers.append(answer)\n",
+    "\n",
+    "# Show the first set of input and output.\n",
+    "print(questions[0])\n",
+    "print(fill(answers[0], replace_whitespace=False))\n",
+    "\n",
+    "# Prepare the data dictionary for fine-tuning Gemma.\n",
+    "data = {\n",
+    "    \"prompts\": questions,\n",
+    "    \"responses\": answers\n",
+    "}"
+   ],
+   "metadata": {
+    "id": "Chd0kZqPtNAT"
+   },
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Activity 1: Load Gemma-4B\n",
+    "\n",
+    "------\n",
+    "> 💻 **Your task**:\n",
+    ">\n",
+    "> Run the next cell to load in the base Gemma-4B model with full 32-bit precision, where all numbers are represented as 32bit floating point numbers.\n",
+    ">\n",
+    "> Does the cell run successfully? Reflect on the output and why this might be happening.\n",
+    ">\n",
+    "------"
+   ],
+   "metadata": {
+    "id": "PT2eWi4Wtyx-"
+   }
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "# Load the Gemma3-4B Keras model.\n",
+    "model = keras_nlp.models.Gemma3CausalLM.from_preset(preset=\"gemma3_4b_text\")\n",
+    "model.summary()"
+   ],
+   "metadata": {
+    "id": "hN_7KvaXt-8I"
+   },
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### What did you observe?\n",
+    "\n",
+    "You should have encountered an error saying `RESOURCE_EXHAUSTED` as well a message indicating how much memory the process attempted to allocate.\n",
+    "\n",
+    "------\n",
+    "> **💭 Reflection:**\n",
+    ">\n",
+    ">Given this output, briefly reflect on these questions:\n",
+    ">\n",
+    ">1. What do you think the error means at a high level?\n",
+    ">\n",
+    ">2. Based on what you have read so far about GPU memory consumers, write down a hypothesis for why this happens.\n",
+    ">\n",
+    "------"
+   ],
+   "metadata": {
+    "id": "H_MfGYCx4m5p"
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Out-of-memory errors\n",
+    "\n",
+    "The `RESOURCE_EXHAUSTED` error is the technical name for an out-of-memory (OOM) error. It means that the GPU ran out of memory while trying to load the model.\n",
+    "\n",
+    "This error highlights that for a model of this size, you cannot even load the model with standard settings. However, this issue is not insurmountable. It is the exact problem that modern efficiency techniques are designed to solve. In the next article, you will learn what takes up so much memory in the GPU. Later on, you will also observe how using techniques like mixed precision can help you to overcome this memory wall.\n",
+    "\n",
+    "In case you are wondering why it was possible to load the Gemma-4B model in the first lab of this course, note that that lab already used some memory efficiency techniques in the background."
+   ],
+   "metadata": {
+    "id": "snEknum9TIkN"
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Summary\n",
+    "\n",
+    "This lab provided a practical demonstration of the hardware limitations involved in training large models. You experienced what it is like to hit the \"memory wall\" again. You further observed that when attempting to fine-tune a large model, it can fail with an out-of-memory error even at the point of loading the parameter weights. In the next activity, you will learn more about the main components that consume of GPU memory."
+   ],
+   "metadata": {
+    "id": "mtPvGi_97gcS"
+   }
+  }
+ ]
 }

--- a/course_7/gdm_lab_7_5_fine_tune_a_model_with_bfloat16.ipynb
+++ b/course_7/gdm_lab_7_5_fine_tune_a_model_with_bfloat16.ipynb
@@ -1,652 +1,569 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "4X3cgmmhcGXX"
-      },
-      "source": [
-        "<img src=\"https://storage.googleapis.com/dm-educational/assets/ai_foundations/GDM-Labs-banner-image-C6-white-bg.png\">"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "Cm5kp5gPcQgk"
-      },
-      "source": [
-        "# Lab: Fine-Tune a Model with bfloat16\n",
-        "\n",
-        "<a href='https://colab.research.google.com/github/google-deepmind/ai-foundations/blob/master/course_7/gdm_lab_7_5_fine_tune_a_model_with_bfloat16.ipynb' target='_parent'><img src='https://colab.research.google.com/assets/colab-badge.svg' alt='Open In Colab'/></a>\n",
-        "\n",
-        "Learn how to successfully train a large model on a single GPU using the bfloat16 data type.\n",
-        "\n",
-        "25 minutes"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "acC8A1A0crE2"
-      },
-      "source": [
-        "##Overview\n",
-        "\n",
-        "In the previous fine-tuning lab \"Hitting a Wall,\" you encountered an out-of-memory error when attempting to load Gemma-4B on a standard 16GB GPU.\n",
-        "\n",
-        "In this lab, you will learn how to load the model parameters using the bfloat16 data type. Combining this technique with LoRA, you can then fine-tune a 4B model on the GPU that is available to you."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "ykoxsIkLctnM"
-      },
-      "source": [
-        "### What you will learn:\n",
-        "\n",
-        "By the end of this lab, you will be able to:\n",
-        "\n",
-        "* Implement the loading of parameters in bfloat16 in Keras.\n",
-        "* Explain how bfloat16 significantly reduces the memory footprint of a model.\n",
-        "* Fine-tune a large model on a resource-constrained GPU."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "OGHgDenJcuJT"
-      },
-      "source": [
-        "### Tasks\n",
-        "\n",
-        "**In this lab, you will**:\n",
-        "\n",
-        "* Load the Gemma-4B model using bfloat16 precision.\n",
-        "* Fine-tune the model to produce flashcards as in course 05 Fine-tune Your Model.\n",
-        "* Reflect on the performance of the fine-tuned model.\n",
-        "\n",
-        "**This lab needs to be run on a GPU. Choose a T4 GPU.** See the section \"How to use Google Colaboratory (Colab)\" below for instructions on how to do this.\n",
-        "\n",
-        "**You also need a Kaggle account** to download the weights of the Gemma 3 model. See the section \"Set up a Kaggle account\" for instructions on how to do this.\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "NDWsJUGcf4Ru"
-      },
-      "source": [
-        "## How to use Google Colaboratory (Colab)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "wlNG_jg-39Zj"
-      },
-      "source": [
-        "Google Colaboratory (also known as Google Colab) is a platform that allows you to run Python code in your browser. The code is written in **cells** that are excuted on a remote server.\n",
-        "\n",
-        "To run a cell, hover over a cell and click on the `run` button to its left. The run button is the circle with the triangle (▶). Alternatively, you can also click on a cell and use the keyboard combination Ctrl+Return (or ⌘+Return if you are using a Mac).\n",
-        "\n",
-        "To try this out, run the following cell. This should print today's day of the week below it."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "UyTT6C0JhGBs"
-      },
-      "outputs": [],
-      "source": [
-        "from datetime import datetime\n",
-        "print(f\"Today is {datetime.today():%A}.\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "pbtgZxrpjm6j"
-      },
-      "source": [
-        "Note that the **order in which you run the cells matters**. When you are working through a lab, make sure to always run all cells in order, otherwise the code might not work. If you take a break while working on a lab, Colab may disconnect you and in that case, you have to execute all cells again before  continuing your work. To make this easier, you can select the cell you are currently working on and then choose _Runtime → Run before_  from the menu above (or use the keyboard combination Ctrl/⌘ + F8). This will re-execute all cells before the current one."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "### Using Colab with a GPU\n",
-        "\n",
-        "Follow these steps to run the activities in this lab on a GPU:\n",
-        "\n",
-        "1.  In the top menu bar, click on **Runtime**.\n",
-        "2.  Select **Change runtime type** from the dropdown menu.\n",
-        "3.  In the pop-up window under **Hardware accelerator**, select **T4 GPU**.\n",
-        "4.  Click **Save**.\n",
-        "\n",
-        "Your Colab session will now restart with GPU access.\n",
-        "\n",
-        "Note that access to GPUs is limited and at times, you may not be able to run this lab on a GPU. All activities will still work but they will run slower and you will have to wait longer for some of the cells to finish running."
-      ],
-      "metadata": {
-        "id": "kN3yE5jSg9zH"
-      }
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "## Set up a Kaggle account\n"
-      ],
-      "metadata": {
-        "id": "n6-dSJ-o_JT9"
-      }
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "\n",
-        "To run this notebook, you will have to sign up for [Kaggle](https://www.kaggle.com), a platform that hosts datasets and models for machine learning. You will also need to sign the agreement for using the Gemma 3 model. This is required so that you can download the weights of the Gemma model for fine-tuning.\n",
-        "\n",
-        "### Step 1: Create your Kaggle account\n",
-        "\n",
-        "* Go to the Kaggle website: https://www.kaggle.com\n",
-        "\n",
-        "* Click the \"Register\" button in the top-right corner.\n",
-        "\n",
-        "* You can sign up using your Google account (recommended for easy Colab integration) or by entering an email and password.\n",
-        "\n",
-        "* Follow the on-screen prompts to complete your registration and verify your email.\n",
-        "\n",
-        "### Step 2: Sign the Gemma 3 model agreement\n",
-        "\n",
-        "* Make sure you are logged into your new Kaggle account.\n",
-        "\n",
-        "* Go directly to the Gemma 3 model card page: https://www.kaggle.com/models/keras/gemma3/keras/\n",
-        "\n",
-        "* You should see a \"Request Access\" button.\n",
-        "\n",
-        "* Click the button, read through the license agreement, and if you are happy to click \"Accept\" to gain access to the model. You must do this before the API will let you download the model.\n",
-        "\n",
-        "### Step 3: Generate your Kaggle API key\n",
-        "\n",
-        "* From any Kaggle page, click on your profile picture or icon in the top-right corner.\n",
-        "\n",
-        "* Select \"Account\" from the drop-down menu.\n",
-        "\n",
-        "* Scroll down to the \"API\" section.\n",
-        "\n",
-        "* Click the \"Create New API Token\" button.\n",
-        "\n",
-        "* This will immediately download a file named `kaggle.json` to your computer. This file contains your username and your secret API key. Keep it safe.\n",
-        "\n",
-        "### Step 4: Set your API Key in  Colab\n",
-        "\n",
-        "* Click the \"key\" icon 🔑 in the left-hand sidebar.\n",
-        "\n",
-        "* You will see the \"Secrets\" panel.\n",
-        "\n",
-        "* Now, open the kaggle.json file you downloaded on your computer. It's a simple text file and will look like this:\n",
-        "\n",
-        "   ```json\n",
-        "   {\"username\":\"YOUR_KAGGLE_USERNAME\",\"key\":\"YOUR_KAGGLE_API_KEY\"}\n",
-        "   ```\n",
-        "* In the Colab Secrets panel, create two new secrets:\n",
-        "\n",
-        "   1. Name: `KAGGLE_USERNAME`\n",
-        "\n",
-        "      Value: Copy and paste `YOUR_KAGGLE_USERNAME` from your `kaggle.json` file.\n",
-        "\n",
-        "   2. Name: `KAGGLE_KEY`\n",
-        "\n",
-        "      Value: Copy and paste `YOUR_KAGGLE_API_KEY` from your `kaggle.json` file.\n",
-        "\n",
-        "* For both secrets, make sure the \"Notebook access\" toggle is switched on.\n"
-      ],
-      "metadata": {
-        "id": "9iS70YEC_Hx8"
-      }
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "LrxGIe_mc3Uo"
-      },
-      "source": [
-        "## Imports\n",
-        "\n",
-        "In this lab, you will use the Keras package for loading and fine-tuning a Gemma model and the Pandas package, for loading the dataset.\n",
-        "\n",
-        "Run the following cell to import the required packages.\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "NrgQ_n_ldZde"
-      },
-      "outputs": [],
-      "source": [
-        "%%capture\n",
-        "# Install the custom package for this course.\n",
-        "!pip install \"git+https://github.com/google-deepmind/ai-foundations.git@main\"\n",
-        "\n",
-        "import os # For setting system variables.\n",
-        "\n",
-        "from google.colab import userdata # For using Colab secrets.\n",
-        "\n",
-        "os.environ[\"KAGGLE_USERNAME\"] = userdata.get(\"KAGGLE_USERNAME\")\n",
-        "os.environ[\"KAGGLE_KEY\"] = userdata.get(\"KAGGLE_KEY\")\n",
-        "\n",
-        "os.environ[\"KERAS_BACKEND\"] = \"jax\"  # Set the Keras backend to JAX.\n",
-        "\n",
-        "# Disable the command buffer pre-allocation to free up memory.\n",
-        "os.environ[\"XLA_FLAGS\"] = \"--xla_gpu_enable_command_buffer=\"\n",
-        "os.environ[\"XLA_PYTHON_CLIENT_MEM_FRACTION\"]=\"0.9\"\n",
-        "\n",
-        "import keras # For defining and training models.\n",
-        "import keras_nlp # For loading the Keras implementation of Gemma.\n",
-        "import pandas as pd # For loading the dataset.\n",
-        "from textwrap import fill # For formatting long paragraphs.\n",
-        "from ai_foundations import formatting # For formatting the training data.\n",
-        "\n",
-        "keras.utils.set_random_seed(812)  # For Keras layers."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "### Load and process data"
-      ],
-      "metadata": {
-        "id": "5my4qxRUihwN"
-      }
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "As in previous labs, the following cell defines a function `format_question` that formats a prompt. It also loads the Africa Galore QA dataset and processes the individual questions so that the data can be used to fine-tune a model to generate answers for flashcards, as in previous courses."
-      ],
-      "metadata": {
-        "id": "XngEInKtii-v"
-      }
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "-QZLk2s3dxuo"
-      },
-      "outputs": [],
-      "source": [
-        "def format_question(\n",
-        "    question: str,\n",
-        "    sot = \"<start_of_turn>\",\n",
-        "    eot = \"<end_of_turn>\"\n",
-        ") -> str:\n",
-        "    \"\"\"\n",
-        "    Formats a question for prompting the model and adds special delimiters at\n",
-        "    the start and end of the question.\n",
-        "\n",
-        "    Args:\n",
-        "      text: The question to be formatted.\n",
-        "      sot: The token to mark the start of a turn.\n",
-        "      eot: The token to mark the end of a turn.\n",
-        "\n",
-        "    Returns:\n",
-        "      Formatted string of the question.\n",
-        "    \"\"\"\n",
-        "\n",
-        "    formatted_q = f\"{sot}user\\n{question}{eot}\\n\"\n",
-        "\n",
-        "    return formatted_q\n",
-        "\n",
-        "# Load the question-answer dataset.\n",
-        "africa_galore_qa = pd.read_json(\n",
-        "    \"https://storage.googleapis.com/dm-educational/assets/ai_foundations/africa_galore_qa_v2.json\"\n",
-        ")\n",
-        "\n",
-        "questions = []  # List of formatted questions.\n",
-        "answers = []  # List of formatted answers.\n",
-        "\n",
-        "for idx, row in africa_galore_qa.iterrows():\n",
-        "    # Run the format_qa function from the previous lab to format the question\n",
-        "    # and the answer.\n",
-        "    question, answer = formatting.format_qa(row)\n",
-        "    questions.append(question)\n",
-        "    answers.append(answer)\n",
-        "\n",
-        "# Show the first set of input and output.\n",
-        "print(questions[0])\n",
-        "print(fill(answers[0], replace_whitespace=False))\n",
-        "\n",
-        "# Prepare the data dictionary for fine-tuning Gemma.\n",
-        "data = {\n",
-        "    \"prompts\": questions,\n",
-        "    \"responses\": answers\n",
-        "}"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "t0CZHtCvh5JC"
-      },
-      "source": [
-        "## Coding Activity 1: Load Gemma-4B parameters\n",
-        "\n",
-        "In the previous fine-tuning lab \"Hitting a Wall,\" the attempt to load Gemma-4B failed because the model's parameters (stored in the default 32-bit format) were too large to fit in the GPU's memory.\n",
-        "\n",
-        "The solution is to load the model using a more memory-efficient number format. You will use bfloat16, which uses 16 bits instead of 32, effectively halving the memory required for the model's weights.\n",
-        "\n",
-        "<br>\n",
-        "\n",
-        "------\n",
-        "> 💻 **Your task**:\n",
-        ">\n",
-        "> In the following cell, load the Gemma-4B model parameters in the `bfloat16` format.\n",
-        ">\n",
-        "> In Keras, you can load the parameters as `bfloat16` as follows:\n",
-        ">\n",
-        "> ```\n",
-        "> model = keras_nlp.models.Gemma3CausalLM.from_preset(preset=<MODEL_NAME>, dtype=\"bfloat16\")\n",
-        "> ```\n",
-        ">\n",
-        "> For the Gemma-4B model, the `<MODEL_NAME>` value is `\"gemma3_4b_text\"`.\n",
-        "------\n",
-        "\n",
-        "<br>\n",
-        "\n",
-        "It should take 2-3 minutes to load the model."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "gaCHPQyyb68v"
-      },
-      "outputs": [],
-      "source": [
-        "# Load the Gemma3-4B Keras model with bfloat16 precision.\n",
-        "model = ... # Add your code here.\n",
-        "model.summary()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "Now that the model has been loaded in with bfloat16, inspect some of the model weights to verify that its parameters are represented as bfloat16 by running the following cell."
-      ],
-      "metadata": {
-        "id": "e7Ujtedk99Je"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "# Access the first transformer block.\n",
-        "first_transformer_block = model.backbone.get_layer(\"decoder_block_0\")\n",
-        "\n",
-        "# Access the attention layer.\n",
-        "attention_layer = first_transformer_block.attention\n",
-        "\n",
-        "# Get the weight matrix for the query projections, and check its dtype.\n",
-        "query_weights = attention_layer.query_dense.kernel\n",
-        "\n",
-        "print(f\"The model's weight precision is {query_weights.dtype}.\")"
-      ],
-      "metadata": {
-        "id": "6v9ZmF2l-GD7"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "-NG5SBs9eOd_"
-      },
-      "source": [
-        "### Activate LoRA\n",
-        "\n",
-        "Even when representing model parameters as bfloat16, you will not be able to perform full-parameter fine-tuning on the available GPU. You will therefore again have to train the model using LoRA. Recall that in course 05 Fine-Tune Your Model, when fine-tuning with LoRA, only the parameters of the low-rank matrices were updated during training. These low-rank matrices constitute a small fraction of the total parameters. This means that the GPU memory needs to store gradients, activations, and optimizer states for only a small number of parameters. This drastically reduces the overall memory requirement. The lower memory requirement is why you can fine-tune a 4B model on a T4 GPU.\n",
-        "\n",
-        "Run the following code to enable LoRA for Gemma-4B with a rank of 4."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "kDGMgiI9eNir"
-      },
-      "outputs": [],
-      "source": [
-        "model.backbone.enable_lora(rank=4)\n",
-        "model.summary()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "## Fine-tune Gemma-4B with bfloat16"
-      ],
-      "metadata": {
-        "id": "_I32dlOBk73-"
-      }
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "Now that LoRA is enabled, you need to configure the training process. This involves setting the hyperparameters that will guide the learning.\n",
-        "\n",
-        "Training with a low-precision format like bfloat16 often requires more careful hyperparameter selection than standard 32-bit training. As the numbers are less precise, the learning process can be more sensitive, so it is important to use settings that result in a stable training process.\n",
-        "\n",
-        "The following cell below sets up the AdamW optimizer with a set of values that have been found to work well for stable bfloat16 fine-tuning. Run the following cell to configure your model for training."
-      ],
-      "metadata": {
-        "id": "w13gZ5ct-ySr"
-      }
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "cs2VVQA0eZaH"
-      },
-      "outputs": [],
-      "source": [
-        "# Set hyperparameters.\n",
-        "optimizer = keras.optimizers.AdamW(\n",
-        "    learning_rate=5e-5,\n",
-        "    weight_decay=0.01,\n",
-        "    beta_1=0.9,\n",
-        "    beta_2=0.95,\n",
-        "    epsilon=1e-6,\n",
-        "    clipnorm=0.5,\n",
-        ")\n",
-        "\n",
-        "# Determine the number of epochs.\n",
-        "num_epochs = 4\n",
-        "\n",
-        "# Set the maximum length.\n",
-        "model.preprocessor.sequence_length = 400\n",
-        "\n",
-        "# Compile the optimizer.\n",
-        "model.compile(\n",
-        "    optimizer=optimizer,\n",
-        ")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "### Monitor training progress\n",
-        "\n",
-        "As for previous fine-tuning runs, you need a method to evaluate the training progress beyond the loss. As before, you will do this by sampling generations from the model after each epoch.\n",
-        "\n",
-        "The following cell creates a Keras callback. This is a helper function that will automatically run code at the end of each epoch. In this case, it will generate and print outputs for three specific test prompts. This allows you to monitor the model's progress in real-time.\n",
-        "\n",
-        "The three test prompts are designed to check different aspects of learning:\n",
-        "\n",
-        "* \"What is Kente cloth?\": This tests if the model is learning the specific knowledge from the fine-tuning dataset.\n",
-        "* \"What is Kilimanjaro?\": This tests generalization, as \"Mount Kilimanjaro\" features in the fine-tuning dataset but the word \"Mount\" is omitted here to make it more difficult.\n",
-        "* \"What is Tokyo?\": Since there is nothing about Tokyo or Japan in the fine-tuning dataset, this checks if the model retains its pre-trained knowledge while learning the new task.\n",
-        "\n",
-        "Run the following cell to define this callback."
-      ],
-      "metadata": {
-        "id": "ilPyfAtJAeiD"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "# Define a list of prompts you want to check after each epoch.\n",
-        "test_prompts = [\n",
-        "    \"What is Kente cloth?\",\n",
-        "    \"What is Kilimanjaro?\",\n",
-        "    \"What is Tokyo?\"\n",
-        "]\n",
-        "\n",
-        "class GenerationMonitor(keras.callbacks.Callback):\n",
-        "    def on_epoch_end(self, epoch, logs=None):\n",
-        "        print(f\"\\n--- Generations after epoch {epoch + 1} ---\")\n",
-        "        for prompt in test_prompts:\n",
-        "            # Format the prompt correctly for the model.\n",
-        "            formatted_prompt = format_question(prompt)\n",
-        "\n",
-        "            # Generate and print the output.\n",
-        "            output = self.model.generate(formatted_prompt, max_length=150)\n",
-        "            print(output)\n",
-        "            print(\"-\" * 20)"
-      ],
-      "metadata": {
-        "id": "lpcH6wAAe5wN"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "Now run the following cells to fine-tune the model using LoRA and the bfloat16 number format. Notice how this does not lead to an out-of-memory error.\n",
-        "\n",
-        "Compare the outputs after each epoch. How do they look?\n",
-        "\n",
-        "The training will take about five minutes per epoch on a T4 GPU. In total, it should take around 20 minutes for four epochs."
-      ],
-      "metadata": {
-        "id": "vu3hD1lzk-uo"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "# Create an instance of the monitoring callback.\n",
-        "generation_callback = GenerationMonitor()\n",
-        "\n",
-        "# Train the model.\n",
-        "history = model.fit(\n",
-        "    data,\n",
-        "    epochs=num_epochs,\n",
-        "    batch_size=1,\n",
-        "    callbacks=[generation_callback],\n",
-        ")"
-      ],
-      "metadata": {
-        "id": "c-7F17BLe6YC"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "### What did you observe?\n",
-        "\n",
-        "In the previous fine-tuning lab \"Hitting a Wall,\" already attempting to load the model with full 32-bit precision resulted in an immediate out-of-memory error. Now, by making a single change - that is, loading the model with bfloat16 instead of 32-bit floating point numbers - you can not only load the model but also fine-tune it with LoRA.\n",
-        "\n",
-        "The output of the training process also shows how the model learned to respond to the questions in the desired flashcard format after training for a few epochs. Notice the initial instability in Epoch 1. For the \"Kente\" prompt, the model generates a repeated, random token (\"KMnO4\"). For the \"Tokyo\" prompt, the model keeps generating \"Category:\" lists. However, after this, the generations improve dramatically. The model produces increasingly coherent text matching the flashcard format. The final generations in Epoch 4 are high-quality, factually accurate, and stylistically correct. This shows that using bfloat16 does not compromise the quality of the trained model.\n",
-        "\n",
-        "You have now successfully trained a 4-billion parameter model on a single GPU, a task that was impossible with standard precision. You have also seen that the final generations are high-quality, indicating that bfloat16 did not significantly harm the model's performance on this task."
-      ],
-      "metadata": {
-        "id": "xB9ae9oAlo9X"
-      }
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "## Summary\n",
-        "\n",
-        "Loading the model parameters with a lower precision number format like bfloat16 allows you to use and fine-tune bigger models with limited GPU resources. As you observed in this lab, by using bfloat16 representations, you were able to load all parameters of the Gemma-4B into memory and even fine-tune the model on a T4 GPU available through Colab. This resulted in a model that is able to generate high-quality responses thanks to the powerful 4-billion parameter foundation model that served as the basis for fine-tuning."
-      ],
-      "metadata": {
-        "id": "IXwi82sWlpJU"
-      }
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "## Solutions\n",
-        "\n",
-        "The following cells provide reference solutions to the coding activities in this notebook. If you really get stuck after trying to solve the activities yourself, you may want to consult these solutions.\n",
-        "\n",
-        "It is recommended that you *only* look at the solutions after you have tried to solve the activities *multiple times*. The best way to learn challenging concepts in computer science and artificial intelligence is to debug your code piece-by-piece until it works, rather than copying existing solutions.\n",
-        "\n",
-        "If you feel stuck, you may want to first try to debug your code. For example, by adding additional print statements to see what your code is doing at every step. This will provide you with a much deeper understanding of the code and the materials. It will also provide you with practice on how to solve challenging coding problems beyond this course.\n",
-        "\n",
-        "To view the solutions for an activity, click on the arrow to the left of the activity name. If you consult the solutions, do not copy and paste them into the cells above. Instead, look at them, and type them manually into the cell. This will help you understand where you went wrong.\n"
-      ],
-      "metadata": {
-        "id": "OChZEs7AZBxn"
-      }
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "### Coding Activity 1"
-      ],
-      "metadata": {
-        "id": "D_rtDcZ9ZIWg"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "model = keras_nlp.models.Gemma3CausalLM.from_preset(\"gemma3_4b_text\", dtype=\"bfloat16\")"
-      ],
-      "metadata": {
-        "id": "_B8aCZuAZCSs"
-      },
-      "execution_count": null,
-      "outputs": []
-    }
-  ],
-  "metadata": {
-    "colab": {
-      "collapsed_sections": [
-        "NDWsJUGcf4Ru",
-        "n6-dSJ-o_JT9",
-        "D_rtDcZ9ZIWg"
-      ],
-      "provenance": [],
-      "gpuType": "T4",
-      "machine_shape": "hm"
-    },
-    "kernelspec": {
-      "display_name": "Python 3",
-      "name": "python3"
-    },
-    "language_info": {
-      "name": "python"
-    },
-    "accelerator": "GPU"
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "4X3cgmmhcGXX"
+   },
+   "source": [
+    "<img src=\"https://storage.googleapis.com/dm-educational/assets/ai_foundations/GDM-Labs-banner-image-C6-white-bg.png\">"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 0
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "Cm5kp5gPcQgk"
+   },
+   "source": [
+    "# Lab: Fine-Tune a Model with bfloat16\n",
+    "\n",
+    "<a href='https://colab.research.google.com/github/google-deepmind/ai-foundations/blob/master/course_7/gdm_lab_7_5_fine_tune_a_model_with_bfloat16.ipynb' target='_parent'><img src='https://colab.research.google.com/assets/colab-badge.svg' alt='Open In Colab'/></a>\n",
+    "\n",
+    "Learn how to successfully train a large model on a single GPU using the bfloat16 data type.\n",
+    "\n",
+    "25 minutes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "acC8A1A0crE2"
+   },
+   "source": [
+    "##Overview\n",
+    "\n",
+    "In the previous fine-tuning lab \"Hitting a Wall,\" you encountered an out-of-memory error when attempting to load Gemma-4B on a standard 16GB GPU.\n",
+    "\n",
+    "In this lab, you will learn how to load the model parameters using the bfloat16 data type. Combining this technique with LoRA, you can then fine-tune a 4B model on the GPU that is available to you."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "ykoxsIkLctnM"
+   },
+   "source": [
+    "### What you will learn:\n",
+    "\n",
+    "By the end of this lab, you will be able to:\n",
+    "\n",
+    "* Implement the loading of parameters in bfloat16 in Keras.\n",
+    "* Explain how bfloat16 significantly reduces the memory footprint of a model.\n",
+    "* Fine-tune a large model on a resource-constrained GPU."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "OGHgDenJcuJT"
+   },
+   "source": [
+    "### Tasks\n",
+    "\n",
+    "**In this lab, you will**:\n",
+    "\n",
+    "* Load the Gemma-4B model using bfloat16 precision.\n",
+    "* Fine-tune the model to produce flashcards as in course 05 Fine-tune Your Model.\n",
+    "* Reflect on the performance of the fine-tuned model.\n",
+    "\n",
+    "**This lab needs to be run on a GPU. Choose a T4 GPU.** See the section \"How to use Google Colaboratory (Colab)\" below for instructions on how to do this.\n",
+    "\n",
+    "**You also need a Kaggle account** to download the weights of the Gemma 3 model. See the section \"Set up a Kaggle account\" for instructions on how to do this.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "NDWsJUGcf4Ru"
+   },
+   "source": [
+    "## How to use Google Colaboratory (Colab)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "wlNG_jg-39Zj"
+   },
+   "source": [
+    "Google Colaboratory (also known as Google Colab) is a platform that allows you to run Python code in your browser. The code is written in **cells** that are excuted on a remote server.\n",
+    "\n",
+    "To run a cell, hover over a cell and click on the `run` button to its left. The run button is the circle with the triangle (▶). Alternatively, you can also click on a cell and use the keyboard combination Ctrl+Return (or ⌘+Return if you are using a Mac).\n",
+    "\n",
+    "To try this out, run the following cell. This should print today's day of the week below it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "UyTT6C0JhGBs"
+   },
+   "outputs": [],
+   "source": [
+    "from datetime import datetime\n",
+    "print(f\"Today is {datetime.today():%A}.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "pbtgZxrpjm6j"
+   },
+   "source": [
+    "Note that the **order in which you run the cells matters**. When you are working through a lab, make sure to always run all cells in order, otherwise the code might not work. If you take a break while working on a lab, Colab may disconnect you and in that case, you have to execute all cells again before  continuing your work. To make this easier, you can select the cell you are currently working on and then choose _Runtime → Run before_  from the menu above (or use the keyboard combination Ctrl/⌘ + F8). This will re-execute all cells before the current one."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Using Colab with a GPU\n",
+    "\n",
+    "Follow these steps to run the activities in this lab on a GPU:\n",
+    "\n",
+    "1.  In the top menu bar, click on **Runtime**.\n",
+    "2.  Select **Change runtime type** from the dropdown menu.\n",
+    "3.  In the pop-up window under **Hardware accelerator**, select **T4 GPU**.\n",
+    "4.  Click **Save**.\n",
+    "\n",
+    "Your Colab session will now restart with GPU access.\n",
+    "\n",
+    "Note that access to GPUs is limited and at times, you may not be able to run this lab on a GPU. All activities will still work but they will run slower and you will have to wait longer for some of the cells to finish running."
+   ],
+   "metadata": {
+    "id": "kN3yE5jSg9zH"
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Set up a Kaggle account\n"
+   ],
+   "metadata": {
+    "id": "n6-dSJ-o_JT9"
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": "\nTo run this notebook, you will have to sign up for [Kaggle](https://www.kaggle.com), a platform that hosts datasets and models for machine learning. You will also need to sign the agreement for using the Gemma 3 model. This is required so that you can download the weights of the Gemma model for fine-tuning.\n\n### Step 1: Create your Kaggle account\n\n* Go to the Kaggle website: https://www.kaggle.com\n\n* Click the \"Register\" button in the top-right corner.\n\n* You can sign up using your Google account (recommended for easy Colab integration) or by entering an email and password.\n\n* Follow the on-screen prompts to complete your registration and verify your email.\n\n### Step 2: Sign the Gemma 3 model agreement\n\n* Make sure you are logged into your new Kaggle account.\n\n* Go directly to the Gemma 3 model card page: https://www.kaggle.com/models/keras/gemma3/keras/\n\n* You should see a \"Request Access\" button.\n\n* Click the button, read through the license agreement, and if you are happy to click \"Accept\" to gain access to the model. You must do this before the API will let you download the model.\n\n### Step 3: Generate your Kaggle API token\n\n* From any Kaggle page, click on your profile picture or icon in the top-right corner.\n\n* Select \"Settings\" from the drop-down menu.\n\n* Scroll down to the \"API\" section.\n\n* Click the \"Generate New Token\" button.\n\n* Copy the token value that is displayed.\n\n### Step 4: Set your API token in Colab\n\n* Click the \"key\" icon 🔑 in the left-hand sidebar.\n\n* You will see the \"Secrets\" panel.\n\n* In the Colab Secrets panel, create a new secret:\n\n   * Name: `KAGGLE_API_TOKEN`\n\n   * Value: Paste the token you copied in Step 3.\n\n* Make sure the \"Notebook access\" toggle is switched on.",
+   "metadata": {
+    "id": "9iS70YEC_Hx8"
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "LrxGIe_mc3Uo"
+   },
+   "source": [
+    "## Imports\n",
+    "\n",
+    "In this lab, you will use the Keras package for loading and fine-tuning a Gemma model and the Pandas package, for loading the dataset.\n",
+    "\n",
+    "Run the following cell to import the required packages.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "NrgQ_n_ldZde"
+   },
+   "outputs": [],
+   "source": "%%capture\n# Install the custom package for this course.\n!pip install \"git+https://github.com/google-deepmind/ai-foundations.git@main\"\n\nimport os # For setting system variables.\n\nfrom google.colab import userdata # For using Colab secrets.\n\nos.environ[\"KAGGLE_API_TOKEN\"] = userdata.get(\"KAGGLE_API_TOKEN\")\n\nos.environ[\"KERAS_BACKEND\"] = \"jax\"  # Set the Keras backend to JAX.\n\n# Disable the command buffer pre-allocation to free up memory.\nos.environ[\"XLA_FLAGS\"] = \"--xla_gpu_enable_command_buffer=\"\nos.environ[\"XLA_PYTHON_CLIENT_MEM_FRACTION\"]=\"0.9\"\n\nimport keras # For defining and training models.\nimport keras_nlp # For loading the Keras implementation of Gemma.\nimport pandas as pd # For loading the dataset.\nfrom textwrap import fill # For formatting long paragraphs.\nfrom ai_foundations import formatting # For formatting the training data.\n\nkeras.utils.set_random_seed(812)  # For Keras layers."
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Load and process data"
+   ],
+   "metadata": {
+    "id": "5my4qxRUihwN"
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "As in previous labs, the following cell defines a function `format_question` that formats a prompt. It also loads the Africa Galore QA dataset and processes the individual questions so that the data can be used to fine-tune a model to generate answers for flashcards, as in previous courses."
+   ],
+   "metadata": {
+    "id": "XngEInKtii-v"
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "-QZLk2s3dxuo"
+   },
+   "outputs": [],
+   "source": [
+    "def format_question(\n",
+    "    question: str,\n",
+    "    sot = \"<start_of_turn>\",\n",
+    "    eot = \"<end_of_turn>\"\n",
+    ") -> str:\n",
+    "    \"\"\"\n",
+    "    Formats a question for prompting the model and adds special delimiters at\n",
+    "    the start and end of the question.\n",
+    "\n",
+    "    Args:\n",
+    "      text: The question to be formatted.\n",
+    "      sot: The token to mark the start of a turn.\n",
+    "      eot: The token to mark the end of a turn.\n",
+    "\n",
+    "    Returns:\n",
+    "      Formatted string of the question.\n",
+    "    \"\"\"\n",
+    "\n",
+    "    formatted_q = f\"{sot}user\\n{question}{eot}\\n\"\n",
+    "\n",
+    "    return formatted_q\n",
+    "\n",
+    "# Load the question-answer dataset.\n",
+    "africa_galore_qa = pd.read_json(\n",
+    "    \"https://storage.googleapis.com/dm-educational/assets/ai_foundations/africa_galore_qa_v2.json\"\n",
+    ")\n",
+    "\n",
+    "questions = []  # List of formatted questions.\n",
+    "answers = []  # List of formatted answers.\n",
+    "\n",
+    "for idx, row in africa_galore_qa.iterrows():\n",
+    "    # Run the format_qa function from the previous lab to format the question\n",
+    "    # and the answer.\n",
+    "    question, answer = formatting.format_qa(row)\n",
+    "    questions.append(question)\n",
+    "    answers.append(answer)\n",
+    "\n",
+    "# Show the first set of input and output.\n",
+    "print(questions[0])\n",
+    "print(fill(answers[0], replace_whitespace=False))\n",
+    "\n",
+    "# Prepare the data dictionary for fine-tuning Gemma.\n",
+    "data = {\n",
+    "    \"prompts\": questions,\n",
+    "    \"responses\": answers\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "t0CZHtCvh5JC"
+   },
+   "source": [
+    "## Coding Activity 1: Load Gemma-4B parameters\n",
+    "\n",
+    "In the previous fine-tuning lab \"Hitting a Wall,\" the attempt to load Gemma-4B failed because the model's parameters (stored in the default 32-bit format) were too large to fit in the GPU's memory.\n",
+    "\n",
+    "The solution is to load the model using a more memory-efficient number format. You will use bfloat16, which uses 16 bits instead of 32, effectively halving the memory required for the model's weights.\n",
+    "\n",
+    "<br>\n",
+    "\n",
+    "------\n",
+    "> 💻 **Your task**:\n",
+    ">\n",
+    "> In the following cell, load the Gemma-4B model parameters in the `bfloat16` format.\n",
+    ">\n",
+    "> In Keras, you can load the parameters as `bfloat16` as follows:\n",
+    ">\n",
+    "> ```\n",
+    "> model = keras_nlp.models.Gemma3CausalLM.from_preset(preset=<MODEL_NAME>, dtype=\"bfloat16\")\n",
+    "> ```\n",
+    ">\n",
+    "> For the Gemma-4B model, the `<MODEL_NAME>` value is `\"gemma3_4b_text\"`.\n",
+    "------\n",
+    "\n",
+    "<br>\n",
+    "\n",
+    "It should take 2-3 minutes to load the model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "gaCHPQyyb68v"
+   },
+   "outputs": [],
+   "source": [
+    "# Load the Gemma3-4B Keras model with bfloat16 precision.\n",
+    "model = ... # Add your code here.\n",
+    "model.summary()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Now that the model has been loaded in with bfloat16, inspect some of the model weights to verify that its parameters are represented as bfloat16 by running the following cell."
+   ],
+   "metadata": {
+    "id": "e7Ujtedk99Je"
+   }
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "# Access the first transformer block.\n",
+    "first_transformer_block = model.backbone.get_layer(\"decoder_block_0\")\n",
+    "\n",
+    "# Access the attention layer.\n",
+    "attention_layer = first_transformer_block.attention\n",
+    "\n",
+    "# Get the weight matrix for the query projections, and check its dtype.\n",
+    "query_weights = attention_layer.query_dense.kernel\n",
+    "\n",
+    "print(f\"The model's weight precision is {query_weights.dtype}.\")"
+   ],
+   "metadata": {
+    "id": "6v9ZmF2l-GD7"
+   },
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "-NG5SBs9eOd_"
+   },
+   "source": [
+    "### Activate LoRA\n",
+    "\n",
+    "Even when representing model parameters as bfloat16, you will not be able to perform full-parameter fine-tuning on the available GPU. You will therefore again have to train the model using LoRA. Recall that in course 05 Fine-Tune Your Model, when fine-tuning with LoRA, only the parameters of the low-rank matrices were updated during training. These low-rank matrices constitute a small fraction of the total parameters. This means that the GPU memory needs to store gradients, activations, and optimizer states for only a small number of parameters. This drastically reduces the overall memory requirement. The lower memory requirement is why you can fine-tune a 4B model on a T4 GPU.\n",
+    "\n",
+    "Run the following code to enable LoRA for Gemma-4B with a rank of 4."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "kDGMgiI9eNir"
+   },
+   "outputs": [],
+   "source": [
+    "model.backbone.enable_lora(rank=4)\n",
+    "model.summary()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Fine-tune Gemma-4B with bfloat16"
+   ],
+   "metadata": {
+    "id": "_I32dlOBk73-"
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Now that LoRA is enabled, you need to configure the training process. This involves setting the hyperparameters that will guide the learning.\n",
+    "\n",
+    "Training with a low-precision format like bfloat16 often requires more careful hyperparameter selection than standard 32-bit training. As the numbers are less precise, the learning process can be more sensitive, so it is important to use settings that result in a stable training process.\n",
+    "\n",
+    "The following cell below sets up the AdamW optimizer with a set of values that have been found to work well for stable bfloat16 fine-tuning. Run the following cell to configure your model for training."
+   ],
+   "metadata": {
+    "id": "w13gZ5ct-ySr"
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "cs2VVQA0eZaH"
+   },
+   "outputs": [],
+   "source": [
+    "# Set hyperparameters.\n",
+    "optimizer = keras.optimizers.AdamW(\n",
+    "    learning_rate=5e-5,\n",
+    "    weight_decay=0.01,\n",
+    "    beta_1=0.9,\n",
+    "    beta_2=0.95,\n",
+    "    epsilon=1e-6,\n",
+    "    clipnorm=0.5,\n",
+    ")\n",
+    "\n",
+    "# Determine the number of epochs.\n",
+    "num_epochs = 4\n",
+    "\n",
+    "# Set the maximum length.\n",
+    "model.preprocessor.sequence_length = 400\n",
+    "\n",
+    "# Compile the optimizer.\n",
+    "model.compile(\n",
+    "    optimizer=optimizer,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Monitor training progress\n",
+    "\n",
+    "As for previous fine-tuning runs, you need a method to evaluate the training progress beyond the loss. As before, you will do this by sampling generations from the model after each epoch.\n",
+    "\n",
+    "The following cell creates a Keras callback. This is a helper function that will automatically run code at the end of each epoch. In this case, it will generate and print outputs for three specific test prompts. This allows you to monitor the model's progress in real-time.\n",
+    "\n",
+    "The three test prompts are designed to check different aspects of learning:\n",
+    "\n",
+    "* \"What is Kente cloth?\": This tests if the model is learning the specific knowledge from the fine-tuning dataset.\n",
+    "* \"What is Kilimanjaro?\": This tests generalization, as \"Mount Kilimanjaro\" features in the fine-tuning dataset but the word \"Mount\" is omitted here to make it more difficult.\n",
+    "* \"What is Tokyo?\": Since there is nothing about Tokyo or Japan in the fine-tuning dataset, this checks if the model retains its pre-trained knowledge while learning the new task.\n",
+    "\n",
+    "Run the following cell to define this callback."
+   ],
+   "metadata": {
+    "id": "ilPyfAtJAeiD"
+   }
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "# Define a list of prompts you want to check after each epoch.\n",
+    "test_prompts = [\n",
+    "    \"What is Kente cloth?\",\n",
+    "    \"What is Kilimanjaro?\",\n",
+    "    \"What is Tokyo?\"\n",
+    "]\n",
+    "\n",
+    "class GenerationMonitor(keras.callbacks.Callback):\n",
+    "    def on_epoch_end(self, epoch, logs=None):\n",
+    "        print(f\"\\n--- Generations after epoch {epoch + 1} ---\")\n",
+    "        for prompt in test_prompts:\n",
+    "            # Format the prompt correctly for the model.\n",
+    "            formatted_prompt = format_question(prompt)\n",
+    "\n",
+    "            # Generate and print the output.\n",
+    "            output = self.model.generate(formatted_prompt, max_length=150)\n",
+    "            print(output)\n",
+    "            print(\"-\" * 20)"
+   ],
+   "metadata": {
+    "id": "lpcH6wAAe5wN"
+   },
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Now run the following cells to fine-tune the model using LoRA and the bfloat16 number format. Notice how this does not lead to an out-of-memory error.\n",
+    "\n",
+    "Compare the outputs after each epoch. How do they look?\n",
+    "\n",
+    "The training will take about five minutes per epoch on a T4 GPU. In total, it should take around 20 minutes for four epochs."
+   ],
+   "metadata": {
+    "id": "vu3hD1lzk-uo"
+   }
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "# Create an instance of the monitoring callback.\n",
+    "generation_callback = GenerationMonitor()\n",
+    "\n",
+    "# Train the model.\n",
+    "history = model.fit(\n",
+    "    data,\n",
+    "    epochs=num_epochs,\n",
+    "    batch_size=1,\n",
+    "    callbacks=[generation_callback],\n",
+    ")"
+   ],
+   "metadata": {
+    "id": "c-7F17BLe6YC"
+   },
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### What did you observe?\n",
+    "\n",
+    "In the previous fine-tuning lab \"Hitting a Wall,\" already attempting to load the model with full 32-bit precision resulted in an immediate out-of-memory error. Now, by making a single change - that is, loading the model with bfloat16 instead of 32-bit floating point numbers - you can not only load the model but also fine-tune it with LoRA.\n",
+    "\n",
+    "The output of the training process also shows how the model learned to respond to the questions in the desired flashcard format after training for a few epochs. Notice the initial instability in Epoch 1. For the \"Kente\" prompt, the model generates a repeated, random token (\"KMnO4\"). For the \"Tokyo\" prompt, the model keeps generating \"Category:\" lists. However, after this, the generations improve dramatically. The model produces increasingly coherent text matching the flashcard format. The final generations in Epoch 4 are high-quality, factually accurate, and stylistically correct. This shows that using bfloat16 does not compromise the quality of the trained model.\n",
+    "\n",
+    "You have now successfully trained a 4-billion parameter model on a single GPU, a task that was impossible with standard precision. You have also seen that the final generations are high-quality, indicating that bfloat16 did not significantly harm the model's performance on this task."
+   ],
+   "metadata": {
+    "id": "xB9ae9oAlo9X"
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Summary\n",
+    "\n",
+    "Loading the model parameters with a lower precision number format like bfloat16 allows you to use and fine-tune bigger models with limited GPU resources. As you observed in this lab, by using bfloat16 representations, you were able to load all parameters of the Gemma-4B into memory and even fine-tune the model on a T4 GPU available through Colab. This resulted in a model that is able to generate high-quality responses thanks to the powerful 4-billion parameter foundation model that served as the basis for fine-tuning."
+   ],
+   "metadata": {
+    "id": "IXwi82sWlpJU"
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Solutions\n",
+    "\n",
+    "The following cells provide reference solutions to the coding activities in this notebook. If you really get stuck after trying to solve the activities yourself, you may want to consult these solutions.\n",
+    "\n",
+    "It is recommended that you *only* look at the solutions after you have tried to solve the activities *multiple times*. The best way to learn challenging concepts in computer science and artificial intelligence is to debug your code piece-by-piece until it works, rather than copying existing solutions.\n",
+    "\n",
+    "If you feel stuck, you may want to first try to debug your code. For example, by adding additional print statements to see what your code is doing at every step. This will provide you with a much deeper understanding of the code and the materials. It will also provide you with practice on how to solve challenging coding problems beyond this course.\n",
+    "\n",
+    "To view the solutions for an activity, click on the arrow to the left of the activity name. If you consult the solutions, do not copy and paste them into the cells above. Instead, look at them, and type them manually into the cell. This will help you understand where you went wrong.\n"
+   ],
+   "metadata": {
+    "id": "OChZEs7AZBxn"
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Coding Activity 1"
+   ],
+   "metadata": {
+    "id": "D_rtDcZ9ZIWg"
+   }
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "model = keras_nlp.models.Gemma3CausalLM.from_preset(\"gemma3_4b_text\", dtype=\"bfloat16\")"
+   ],
+   "metadata": {
+    "id": "_B8aCZuAZCSs"
+   },
+   "execution_count": null,
+   "outputs": []
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "collapsed_sections": [
+    "NDWsJUGcf4Ru",
+    "n6-dSJ-o_JT9",
+    "D_rtDcZ9ZIWg"
+   ],
+   "provenance": [],
+   "gpuType": "T4",
+   "machine_shape": "hm"
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  },
+  "accelerator": "GPU"
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
 }

--- a/course_7/gdm_lab_7_6_apply_gradient_accumulation.ipynb
+++ b/course_7/gdm_lab_7_6_apply_gradient_accumulation.ipynb
@@ -1,886 +1,780 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "4X3cgmmhcGXX"
-      },
-      "source": [
-        "<img src=\"https://storage.googleapis.com/dm-educational/assets/ai_foundations/GDM-Labs-banner-image-C6-white-bg.png\">"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "Cm5kp5gPcQgk"
-      },
-      "source": [
-        "# Lab: Apply Gradient Accumulation\n",
-        "\n",
-        "<a href='https://colab.research.google.com/github/google-deepmind/ai-foundations/blob/master/course_7/gdm_lab_7_6_apply_gradient_accumulation.ipynb' target='_parent'><img src='https://colab.research.google.com/assets/colab-badge.svg' alt='Open In Colab'/></a>\n",
-        "\n",
-        "Learn how to simulate a larger batch size on a memory-constrained GPU using gradient accumulation.\n",
-        "\n",
-        "30 minutes"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "acC8A1A0crE2"
-      },
-      "source": [
-        "##Overview\n",
-        "\n",
-        "Previously, you have explored how using a larger batch size can lead to more stable training and improve the efficiency of the GPU. However, you have also experienced that GPU memory is a critical bottleneck. So what happens when you want the benefits of a larger batch size, but your GPU doesn't have enough memory to handle it?\n",
-        "\n",
-        "In this lab, you will encounter this exact problem. You will first attempt to train the Gemma-4B model with a larger batch size. Then, you will learn how to use **gradient accumulation** to achieve the same result successfully on your resource-constrained GPU."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "ykoxsIkLctnM"
-      },
-      "source": [
-        "### What you will learn:\n",
-        "\n",
-        "By the end of this lab, you will be able to:\n",
-        "\n",
-        "* Explain why a larger batch size can cause out-of-memory errors.\n",
-        "* Describe the concept of gradient accumulation.\n",
-        "* Implement gradient accumulation in Keras to train with a larger effective batch size."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "OGHgDenJcuJT"
-      },
-      "source": [
-        "### Tasks\n",
-        "\n",
-        "**In this lab, you will**:\n",
-        "* Attempt to finetune Gemma-4B with a batch size of 2 and observe the memory error.\n",
-        "* Reconfigure the optimizer to use gradient accumulation.\n",
-        "* Fine-tune the model successfully by simulating a larger batch size of 8.\n",
-        "\n",
-        " **This lab needs to be run on a GPU. Choose a T4 GPU.** See the section \"How to use Google Colaboratory (Colab)\" below for instructions on how to do this.\n",
-        "\n",
-        " **You also need a Kaggle account** to download the weights of the Gemma 3 model. See the section \"Set up a Kaggle account\" for instructions on how to do this.\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "NDWsJUGcf4Ru"
-      },
-      "source": [
-        "## How to use Google Colaboratory (Colab)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "wlNG_jg-39Zj"
-      },
-      "source": [
-        "Google Colaboratory (also known as Google Colab) is a platform that allows you to run Python code in your browser. The code is written in **cells** that are excuted on a remote server.\n",
-        "\n",
-        "To run a cell, hover over a cell and click on the `run` button to its left. The run button is the circle with the triangle (▶). Alternatively, you can also click on a cell and use the keyboard combination Ctrl+Return (or ⌘+Return if you are using a Mac).\n",
-        "\n",
-        "To try this out, run the following cell. This should print today's day of the week below it."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "UyTT6C0JhGBs"
-      },
-      "outputs": [],
-      "source": [
-        "from datetime import datetime\n",
-        "print(f\"Today is {datetime.today():%A}.\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "pbtgZxrpjm6j"
-      },
-      "source": [
-        "Note that the **order in which you run the cells matters**. When you are working through a lab, make sure to always run all cells in order, otherwise the code might not work. If you take a break while working on a lab, Colab may disconnect you and in that case, you have to execute all cells again before  continuing your work. To make this easier, you can select the cell you are currently working on and then choose _Runtime → Run before_  from the menu above (or use the keyboard combination Ctrl/⌘ + F8). This will re-execute all cells before the current one."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "### Using Colab with a GPU\n",
-        "\n",
-        "Follow these steps to run the activities in this lab on a GPU:\n",
-        "\n",
-        "1.  In the top menu bar, click on **Runtime**.\n",
-        "2.  Select **Change runtime type** from the dropdown menu.\n",
-        "3.  In the pop-up window under **Hardware accelerator**, select **T4 GPU**.\n",
-        "4.  Click **Save**.\n",
-        "\n",
-        "Your Colab session will now restart with GPU access.\n",
-        "\n",
-        "Note that access to GPUs is limited and at times, you may not be able to run this lab on a GPU. All activities will still work but they will run slower and you will have to wait longer for some of the cells to finish running."
-      ],
-      "metadata": {
-        "id": "kN3yE5jSg9zH"
-      }
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "## Set up a Kaggle account\n"
-      ],
-      "metadata": {
-        "id": "n6-dSJ-o_JT9"
-      }
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "\n",
-        "To run this notebook, you will have to sign up for [Kaggle](https://www.kaggle.com), a platform that hosts datasets and models for machine learning. You will also need to sign the agreement for using the Gemma 3 model. This is required so that you can download the weights of the Gemma model for fine-tuning.\n",
-        "\n",
-        "### Step 1: Create your Kaggle account\n",
-        "\n",
-        "* Go to the Kaggle website: https://www.kaggle.com\n",
-        "\n",
-        "* Click the \"Register\" button in the top-right corner.\n",
-        "\n",
-        "* You can sign up using your Google account (recommended for easy Colab integration) or by entering an email and password.\n",
-        "\n",
-        "* Follow the on-screen prompts to complete your registration and verify your email.\n",
-        "\n",
-        "### Step 2: Sign the Gemma 3 model agreement\n",
-        "\n",
-        "* Make sure you are logged into your new Kaggle account.\n",
-        "\n",
-        "* Go directly to the Gemma 3 model card page: https://www.kaggle.com/models/keras/gemma3/keras/\n",
-        "\n",
-        "* You should see a \"Request Access\" button.\n",
-        "\n",
-        "* Click the button, read through the license agreement, and if you are happy to, click \"Accept\" to gain access to the model. You must do this before the API will let you download the model.\n",
-        "\n",
-        "### Step 3: Generate your Kaggle API key\n",
-        "\n",
-        "* From any Kaggle page, click on your profile picture or icon in the top-right corner.\n",
-        "\n",
-        "* Select \"Account\" from the drop-down menu.\n",
-        "\n",
-        "* Scroll down to the \"API\" section.\n",
-        "\n",
-        "* Click the \"Create New API Token\" button.\n",
-        "\n",
-        "* This will immediately download a file named `kaggle.json` to your computer. This file contains your username and your secret API key. Keep it safe.\n",
-        "\n",
-        "### Step 4: Set your API Key in  Colab\n",
-        "\n",
-        "* Click the \"key\" icon 🔑 in the left-hand sidebar.\n",
-        "\n",
-        "* You will see the \"Secrets\" panel.\n",
-        "\n",
-        "* Now, open the kaggle.json file you downloaded on your computer. It's a simple text file and will look like this:\n",
-        "\n",
-        "   ```json\n",
-        "   {\"username\":\"YOUR_KAGGLE_USERNAME\",\"key\":\"YOUR_KAGGLE_API_KEY\"}\n",
-        "   ```\n",
-        "* In the Colab Secrets panel, create two new secrets:\n",
-        "\n",
-        "   1. Name: `KAGGLE_USERNAME`\n",
-        "\n",
-        "      Value: Copy and paste `YOUR_KAGGLE_USERNAME` from your `kaggle.json` file.\n",
-        "\n",
-        "   2. Name: `KAGGLE_KEY`\n",
-        "\n",
-        "      Value: Copy and paste `YOUR_KAGGLE_API_KEY` from your `kaggle.json` file.\n",
-        "\n",
-        "* For both secrets, make sure the \"Notebook access\" toggle is switched on.\n"
-      ],
-      "metadata": {
-        "id": "9iS70YEC_Hx8"
-      }
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "LrxGIe_mc3Uo"
-      },
-      "source": [
-        "## Imports\n",
-        "\n",
-        "In this lab, you will use the Keras package for loading and fine-tuning a Gemma model and the Pandas package, for loading the dataset.\n",
-        "\n",
-        "Run the following cell to import the required packages.\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "NrgQ_n_ldZde"
-      },
-      "outputs": [],
-      "source": [
-        "%%capture\n",
-        "# Install the custom package for this course.\n",
-        "!pip install \"git+https://github.com/google-deepmind/ai-foundations.git@main\"\n",
-        "\n",
-        "import os # For setting system variables.\n",
-        "\n",
-        "from google.colab import userdata # For using Colab secrets.\n",
-        "\n",
-        "os.environ[\"KAGGLE_USERNAME\"] = userdata.get(\"KAGGLE_USERNAME\")\n",
-        "os.environ[\"KAGGLE_KEY\"] = userdata.get(\"KAGGLE_KEY\")\n",
-        "\n",
-        "os.environ[\"KERAS_BACKEND\"] = \"jax\"  # Set the Keras backend to JAX.\n",
-        "# Disable the command buffer pre-allocation to free up memory.\n",
-        "os.environ[\"XLA_FLAGS\"] = \"--xla_gpu_enable_command_buffer=\"\n",
-        "os.environ[\"XLA_PYTHON_CLIENT_MEM_FRACTION\"]=\"0.9\"\n",
-        "\n",
-        "import keras # For defining and training models.\n",
-        "import keras_nlp # For loading the Keras implementation of Gemma.\n",
-        "import pandas as pd # For loading the dataset.\n",
-        "from textwrap import fill # For formatting long paragraphs.\n",
-        "from ai_foundations import formatting # For formatting the training data.\n",
-        "\n",
-        "keras.utils.set_random_seed(812)  # For Keras layers."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "## Load and process data\n",
-        "\n",
-        "As in previous labs, the following cell defines a function `format_question` that formats a prompt. It also loads the Africa Galore QA dataset and processes the individual questions so that the data can be used to fine-tune a model to generate answers for flashcards, as in previous courses."
-      ],
-      "metadata": {
-        "id": "5my4qxRUihwN"
-      }
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "-QZLk2s3dxuo"
-      },
-      "outputs": [],
-      "source": [
-        "def format_question(\n",
-        "    question: str,\n",
-        "    sot = \"<start_of_turn>\",\n",
-        "    eot = \"<end_of_turn>\"\n",
-        ") -> str:\n",
-        "    \"\"\"\n",
-        "    Formats a question for prompting the model and adds special delimiters at\n",
-        "    the start and end of the question.\n",
-        "\n",
-        "    Args:\n",
-        "      text: The question to be formatted.\n",
-        "      sot: The token to mark the start of a turn.\n",
-        "      eot: The token to mark the end of a turn.\n",
-        "\n",
-        "    Returns:\n",
-        "      Formatted string of the question.\n",
-        "    \"\"\"\n",
-        "\n",
-        "    formatted_q = f\"{sot}user\\n{question}{eot}\\n\"\n",
-        "\n",
-        "    return formatted_q\n",
-        "\n",
-        "# Load the question-answer dataset.\n",
-        "africa_galore_qa = pd.read_json(\n",
-        "    \"https://storage.googleapis.com/dm-educational/assets/ai_foundations/africa_galore_qa_v2.json\"\n",
-        ")\n",
-        "\n",
-        "questions = []  # List of formatted questions.\n",
-        "answers = []  # List of formatted answers.\n",
-        "\n",
-        "for idx, row in africa_galore_qa.iterrows():\n",
-        "    # Run the format_qa function from the previous lab to format the question\n",
-        "    # and the answer.\n",
-        "    question, answer = formatting.format_qa(row)\n",
-        "    questions.append(question)\n",
-        "    answers.append(answer)\n",
-        "\n",
-        "# Show the first set of input and output.\n",
-        "print(questions[0])\n",
-        "print(fill(answers[0], replace_whitespace=False))\n",
-        "\n",
-        "# Prepare the data dictionary for fine-tuning Gemma.\n",
-        "data = {\n",
-        "    \"prompts\": questions,\n",
-        "    \"responses\": answers\n",
-        "}"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "t0CZHtCvh5JC"
-      },
-      "source": [
-        "## Coding Activity 1: Fine-tune with a larger batch size\n",
-        "\n",
-        "As you have previously encountered, by loading the data in batches you can:\n",
-        "\n",
-        "* Improve training stability. This is because processing only a single datapoint at a time can introduce more noise when estimating gradients.\n",
-        "\n",
-        "* Improve training efficiency by leveraging the parallel processing ability of GPUs to increase the amount of data being processed at once.\n",
-        "\n",
-        "What happens when you try to increase the batch size for training Gemma-4B?\n",
-        "\n",
-        "------\n",
-        "> 💻 **Your task**:\n",
-        ">\n",
-        "> Run the following four cells to load the model, activate LoRA, set the hyperparameters, define the callback function, and set up the training code.\n",
-        ">\n",
-        "> Then, in the cell that calls the `model.fit()` method, change the `batch_size` value to 4.\n",
-        ">\n",
-        "> Observe what happens when you attempt to run training.\n",
-        "\n",
-        "Note: It may take a few minutes before you see any output.\n",
-        "------"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "gaCHPQyyb68v"
-      },
-      "outputs": [],
-      "source": [
-        "# Load the Gemma3-4B Keras model with bfloat16 precision.\n",
-        "model = keras_nlp.models.Gemma3CausalLM.from_preset(\n",
-        "    preset=\"gemma3_4b_text\", dtype=\"bfloat16\"\n",
-        ")\n",
-        "model.summary()"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "kDGMgiI9eNir"
-      },
-      "outputs": [],
-      "source": [
-        "model.backbone.enable_lora(rank=4)\n",
-        "model.summary()"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "cs2VVQA0eZaH"
-      },
-      "outputs": [],
-      "source": [
-        "# Set hyperparameters.\n",
-        "optimizer = keras.optimizers.AdamW(\n",
-        "    learning_rate=1e-4,\n",
-        "    weight_decay=0.01,\n",
-        "    beta_1=0.9,\n",
-        "    beta_2=0.95,\n",
-        "    epsilon=1e-6,\n",
-        "    clipnorm=0.5,\n",
-        ")\n",
-        "\n",
-        "# Determine the number of epochs.\n",
-        "num_epochs = 4\n",
-        "\n",
-        "# Set the maximum length.\n",
-        "model.preprocessor.sequence_length = 400\n",
-        "\n",
-        "# Compile the optimizer.\n",
-        "model.compile(\n",
-        "    optimizer=optimizer,\n",
-        ")"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "# Define a list of prompts you want to check after each epoch.\n",
-        "test_prompts = [\n",
-        "    \"What is Kente cloth?\",\n",
-        "    \"What is Kilimanjaro?\",\n",
-        "    \"What is Tokyo?\"\n",
-        "]\n",
-        "\n",
-        "class GenerationMonitor(keras.callbacks.Callback):\n",
-        "    def on_epoch_end(self, epoch, logs=None):\n",
-        "        print(f\"\\n--- Generations after epoch {epoch + 1} ---\")\n",
-        "        for prompt in test_prompts:\n",
-        "            # Format the prompt correctly for the model.\n",
-        "            formatted_prompt = format_question(prompt)\n",
-        "\n",
-        "            # Generate and print the output.\n",
-        "            output = self.model.generate(formatted_prompt, max_length=150)\n",
-        "            print(output)\n",
-        "            print(\"-\" * 20)"
-      ],
-      "metadata": {
-        "id": "lpcH6wAAe5wN"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "# Create an instance of the monitoring callback.\n",
-        "generation_callback = GenerationMonitor()\n",
-        "\n",
-        "# Train the model.\n",
-        "history = model.fit(\n",
-        "    data,\n",
-        "    epochs=num_epochs,\n",
-        "    batch_size=..., # Add your code here.\n",
-        "    callbacks=[generation_callback],\n",
-        ")"
-      ],
-      "metadata": {
-        "id": "c-7F17BLe6YC"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "### What did you observe?\n",
-        "\n",
-        "You should observe a `RESOURCE_EXHAUSTED` error in the output above. This is very similar to the error you observed in the lab where you attempted to load Gemma-4B with 32-bit floating point numbers.\n",
-        "\n",
-        "This is again an out-of-memory error. It means that the GPU ran out of its dedicated memory while trying to execute the training step.\n",
-        "\n",
-        "The key line is at the end:\n",
-        "\n",
-        "`Out of memory while trying to allocate 52428800 bytes.`\n",
-        "\n",
-        "This tells you the GPU needed to allocate over 52 MB of additional memory for this one step, but it did not have enough free space.\n",
-        "\n",
-        "In the context of this lab, this happened because increasing the batch size from 1 to 4 increased the amount of activations that needed to be stored in memory during the forward pass by a factor of 4. This change was enough to exceed the GPU's memory limit."
-      ],
-      "metadata": {
-        "id": "xB9ae9oAlo9X"
-      }
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "### Restart your Colab session\n",
-        "\n",
-        "Sometimes, especially when working with large models, it is best to clear all variables and free up the GPU's memory for the next task. The most reliable way to do this is to restart your session.\n",
-        "\n",
-        "Before continuing with Coding Activity 2, follow these steps to restart your Colab session:\n",
-        "\n",
-        "1. In the top menu bar, click **Runtime**.\n",
-        "\n",
-        "2. Select **Restart session** from the dropdown menu.\n",
-        "\n",
-        "3. In the pop-up window, click **Yes** to confirm.\n",
-        "\n",
-        "Your Colab session will now restart with a fresh environment. Note that this clears all of your variables and imported libraries, so you will need to re-run the imports and any set-up cells again before proceeding. These are copied below for convenience, so you can start running all cells from the **Coding Activity 2** section."
-      ],
-      "metadata": {
-        "id": "JlLivcuy7cWB"
-      }
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "## Imports"
-      ],
-      "metadata": {
-        "id": "p3KzPKPu8rPb"
-      }
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "y4oMCR158OWm"
-      },
-      "outputs": [],
-      "source": [
-        "%%capture\n",
-        "# Install the custom package for this course.\n",
-        "!pip install \"git+https://github.com/google-deepmind/ai-foundations.git@main\"\n",
-        "\n",
-        "import os # For setting system variables.\n",
-        "\n",
-        "from google.colab import userdata # For using Colab secrets.\n",
-        "\n",
-        "os.environ[\"KAGGLE_USERNAME\"] = userdata.get(\"KAGGLE_USERNAME\")\n",
-        "os.environ[\"KAGGLE_KEY\"] = userdata.get(\"KAGGLE_KEY\")\n",
-        "\n",
-        "os.environ[\"KERAS_BACKEND\"] = \"jax\"  # Set the Keras backend to JAX.\n",
-        "# Disable the command buffer pre-allocation to free up memory.\n",
-        "os.environ[\"XLA_FLAGS\"] = \"--xla_gpu_enable_command_buffer=\"\n",
-        "os.environ[\"XLA_PYTHON_CLIENT_MEM_FRACTION\"]=\"0.9\"\n",
-        "\n",
-        "import keras # For defining and training models.\n",
-        "import keras_nlp # For loading the Keras implementation of Gemma.\n",
-        "import pandas as pd # For loading the dataset.\n",
-        "from textwrap import fill # For formatting long paragraphs.\n",
-        "from ai_foundations import formatting # For formatting the training data.\n",
-        "\n",
-        "keras.utils.set_random_seed(812)  # For Keras layers."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "## Data preprocessing"
-      ],
-      "metadata": {
-        "id": "lrCUW6u-8OWm"
-      }
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "noai9jtG8OWm"
-      },
-      "outputs": [],
-      "source": [
-        "def format_question(\n",
-        "    question: str,\n",
-        "    sot = \"<start_of_turn>\",\n",
-        "    eot = \"<end_of_turn>\"\n",
-        ") -> str:\n",
-        "    \"\"\"\n",
-        "    Formats a question for prompting the model and adds special delimiters at\n",
-        "    the start and end of the question.\n",
-        "\n",
-        "    Args:\n",
-        "      text: The question to be formatted.\n",
-        "      sot: The token to mark the start of a turn.\n",
-        "      eot: The token to mark the end of a turn.\n",
-        "\n",
-        "    Returns:\n",
-        "      Formatted string of the question.\n",
-        "    \"\"\"\n",
-        "\n",
-        "    formatted_q = f\"{sot}user\\n{question}{eot}\\n\"\n",
-        "\n",
-        "    return formatted_q\n",
-        "\n",
-        "# Load the question-answer dataset.\n",
-        "africa_galore_qa = pd.read_json(\n",
-        "    \"https://storage.googleapis.com/dm-educational/assets/ai_foundations/africa_galore_qa_v2.json\"\n",
-        ")\n",
-        "\n",
-        "questions = []  # List of formatted questions.\n",
-        "answers = []  # List of formatted answers.\n",
-        "\n",
-        "for idx, row in africa_galore_qa.iterrows():\n",
-        "    # Run the format_qa function from the previous lab to format the question\n",
-        "    # and the answer.\n",
-        "    question, answer = formatting.format_qa(row)\n",
-        "    questions.append(question)\n",
-        "    answers.append(answer)\n",
-        "\n",
-        "# Show the first set of input and output.\n",
-        "print(questions[0])\n",
-        "print(fill(answers[0], replace_whitespace=False))\n",
-        "\n",
-        "# Prepare the data dictionary for fine-tuning Gemma.\n",
-        "data = {\n",
-        "    \"prompts\": questions,\n",
-        "    \"responses\": answers\n",
-        "}"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "## Coding Activity 2: Fine-tune with gradient accumulation"
-      ],
-      "metadata": {
-        "id": "dbfJm6wlQFID"
-      }
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "You have just confirmed that your GPU cannot handle a physical batch size of 4. One remedy to this issue is to simulate a larger batch size using **gradient accumulation**.\n",
-        "\n",
-        "This technique works by performing the forward and backward passes on several smaller batches and accumulating (summing) their gradients. Only after processing a specified number of small batches does the optimizer update the model's weights using the combined gradient. This achieves the same stable learning signal as a large batch, without the high memory cost."
-      ],
-      "metadata": {
-        "id": "ncBp6REZ8bmq"
-      }
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "Run the following cells to load and process the data again and to load and prepare the model for fine-tuning."
-      ],
-      "metadata": {
-        "id": "K6xPAYrnV4ki"
-      }
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "T0EklPvlQFiW"
-      },
-      "outputs": [],
-      "source": [
-        "# Load the Gemma3-4B Keras model with bfloat16 precision.\n",
-        "model = keras_nlp.models.Gemma3CausalLM.from_preset(\n",
-        "    preset=\"gemma3_4b_text\", dtype=\"bfloat16\"\n",
-        ")\n",
-        "model.summary()"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "E3wJ-KqKQFiW"
-      },
-      "outputs": [],
-      "source": [
-        "model.backbone.enable_lora(rank=4)\n",
-        "model.summary()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "------\n",
-        "> 💻 **Your task**:\n",
-        ">\n",
-        "> In the following cell, configure the `AdamW` optimizer to use gradient accumulation.\n",
-        ">\n",
-        "> To do this, you need to add the `gradient_accumulation_steps` argument directly to the optimizer. Configure it to simulate a batch size of **8** (i.e., 8 times as large as the physical batch size).\n",
-        ">\n",
-        "> ```\n",
-        "> optimizer = keras.optimizers.AdamW(\n",
-        ">    learning_rate=1e-4,\n",
-        ">    ...,\n",
-        ">    gradient_accumulation_steps=<NUM_STEPS>\n",
-        ">)\n",
-        "> ```\n",
-        ">\n",
-        "------"
-      ],
-      "metadata": {
-        "id": "BeAerBzkdM3E"
-      }
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "SrtWS22qQFiW"
-      },
-      "outputs": [],
-      "source": [
-        "# Set hyperparameters.\n",
-        "optimizer = keras.optimizers.AdamW(\n",
-        "    # Multiply the learning rate to match the new effective batch size.\n",
-        "    learning_rate=8e-4,\n",
-        "    weight_decay=0.01,\n",
-        "    beta_1=0.9,\n",
-        "    beta_2=0.95,\n",
-        "    epsilon=1e-6,\n",
-        "    clipnorm=0.5,\n",
-        "    # Add your code here.\n",
-        ")\n",
-        "\n",
-        "# Determine the number of epochs.\n",
-        "num_epochs = 4\n",
-        "\n",
-        "# Set the maximum length.\n",
-        "model.preprocessor.sequence_length = 400\n",
-        "\n",
-        "# Compile the optimizer.\n",
-        "model.compile(\n",
-        "    optimizer=optimizer,\n",
-        ")"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "# Define a list of prompts you want to check after each epoch.\n",
-        "test_prompts = [\n",
-        "    \"What is Kente cloth?\",\n",
-        "    \"What is Kilimanjaro?\",\n",
-        "    \"What is Tokyo?\"\n",
-        "]\n",
-        "\n",
-        "class GenerationMonitor(keras.callbacks.Callback):\n",
-        "    def on_epoch_end(self, epoch, logs=None):\n",
-        "        print(f\"\\n--- Generations after epoch {epoch + 1} ---\")\n",
-        "        for prompt in test_prompts:\n",
-        "            # Format the prompt correctly for the model.\n",
-        "            formatted_prompt = format_question(prompt)\n",
-        "\n",
-        "            # Generate and print the output.\n",
-        "            output = self.model.generate(formatted_prompt, max_length=150)\n",
-        "            print(output)\n",
-        "            print(\"-\" * 20)"
-      ],
-      "metadata": {
-        "id": "WqtCcY4RQFiW"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "# Create an instance of the monitoring callback.\n",
-        "generation_callback = GenerationMonitor()\n",
-        "\n",
-        "# Train the model.\n",
-        "history = model.fit(\n",
-        "    data,\n",
-        "    epochs=num_epochs,\n",
-        "    batch_size=1,\n",
-        "    callbacks=[generation_callback],\n",
-        ")"
-      ],
-      "metadata": {
-        "id": "AdkFVT5XQFiY"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "### What did you observe?\n",
-        "\n",
-        "Across epochs, you likely observed that the generations become steadily more coherent and on-topic. After one epoch, there is still some incoherence. However, notice that the model does not generate any single-token loops like the \"KMnO4\" output from the previous training run in the lab \"Fine-Tune a Model with bfloat16.\" By the end of the second epoch, the outputs are fluent and factual.\n",
-        "\n",
-        "The prior lab's training run used a physical batch size of 1. In comparison, this run with gradient accumulation, resulted in more coherent results more quickly and finished with a lower loss and higher accuracy. This demonstrates that gradient accumulation improves training stability and leads to smoother training dynamics."
-      ],
-      "metadata": {
-        "id": "Ytks-Qfq_FLn"
-      }
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "## Summary\n",
-        "\n",
-        "This lab introduced you to another practical solution for training with limited GPU resources. You explored how you can use a larger effective batch size than your GPU's memory can physically handle. This can be done through **gradient accumulation**. By accumulating gradients over several smaller batches before updating the weights, you can successfully simulate a larger batch size, gaining the benefit of more stable gradients without the high memory cost."
-      ],
-      "metadata": {
-        "id": "IXwi82sWlpJU"
-      }
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "## Solutions\n",
-        "\n",
-        "The following cells provide reference solutions to the coding activities in this notebook. If you really get stuck after trying to solve the activities yourself, you may want to consult these solutions.\n",
-        "\n",
-        "It is recommended that you *only* look at the solutions after you have tried to solve the activities *multiple times*. The best way to learn challenging concepts in computer science and artificial intelligence is to debug your code piece-by-piece until it works, rather than copying existing solutions.\n",
-        "\n",
-        "If you feel stuck, you may want to first try to debug your code. For example, by adding additional print statements to see what your code is doing at every step. This will provide you with a much deeper understanding of the code and the materials. It will also provide you with practice on how to solve challenging coding problems beyond this course.\n",
-        "\n",
-        "To view the solutions for an activity, click on the arrow to the left of the activity name. If you consult the solutions, do not copy and paste them into the cells above. Instead, look at them, and type them manually into the cell. This will help you understand where you went wrong."
-      ],
-      "metadata": {
-        "id": "OChZEs7AZBxn"
-      }
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "### Coding Activity 1"
-      ],
-      "metadata": {
-        "id": "D_rtDcZ9ZIWg"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "# Train the model.\n",
-        "history = model.fit(\n",
-        "    data,\n",
-        "    epochs=num_epochs,\n",
-        "    batch_size=4,\n",
-        "    callbacks=[generation_callback],\n",
-        ")"
-      ],
-      "metadata": {
-        "id": "_B8aCZuAZCSs"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "### Coding Activity 2"
-      ],
-      "metadata": {
-        "id": "usZaaLYES2p0"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "# Set hyperparameters.\n",
-        "optimizer = keras.optimizers.AdamW(\n",
-        "    learning_rate=8e-4, # Multiply the learning rate to match the new effective batch size.\n",
-        "    weight_decay=0.01,\n",
-        "    beta_1=0.9,\n",
-        "    beta_2=0.95,\n",
-        "    epsilon=1e-6,\n",
-        "    clipnorm=0.5,\n",
-        "    gradient_accumulation_steps=8,\n",
-        ")"
-      ],
-      "metadata": {
-        "id": "pXVE-zpoS30a"
-      },
-      "execution_count": null,
-      "outputs": []
-    }
-  ],
-  "metadata": {
-    "colab": {
-      "collapsed_sections": [
-        "NDWsJUGcf4Ru",
-        "n6-dSJ-o_JT9",
-        "OChZEs7AZBxn",
-        "D_rtDcZ9ZIWg",
-        "usZaaLYES2p0"
-      ],
-      "provenance": [],
-      "gpuType": "T4"
-    },
-    "kernelspec": {
-      "display_name": "Python 3",
-      "name": "python3"
-    },
-    "language_info": {
-      "name": "python"
-    },
-    "accelerator": "GPU"
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "4X3cgmmhcGXX"
+   },
+   "source": [
+    "<img src=\"https://storage.googleapis.com/dm-educational/assets/ai_foundations/GDM-Labs-banner-image-C6-white-bg.png\">"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 0
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "Cm5kp5gPcQgk"
+   },
+   "source": [
+    "# Lab: Apply Gradient Accumulation\n",
+    "\n",
+    "<a href='https://colab.research.google.com/github/google-deepmind/ai-foundations/blob/master/course_7/gdm_lab_7_6_apply_gradient_accumulation.ipynb' target='_parent'><img src='https://colab.research.google.com/assets/colab-badge.svg' alt='Open In Colab'/></a>\n",
+    "\n",
+    "Learn how to simulate a larger batch size on a memory-constrained GPU using gradient accumulation.\n",
+    "\n",
+    "30 minutes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "acC8A1A0crE2"
+   },
+   "source": [
+    "##Overview\n",
+    "\n",
+    "Previously, you have explored how using a larger batch size can lead to more stable training and improve the efficiency of the GPU. However, you have also experienced that GPU memory is a critical bottleneck. So what happens when you want the benefits of a larger batch size, but your GPU doesn't have enough memory to handle it?\n",
+    "\n",
+    "In this lab, you will encounter this exact problem. You will first attempt to train the Gemma-4B model with a larger batch size. Then, you will learn how to use **gradient accumulation** to achieve the same result successfully on your resource-constrained GPU."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "ykoxsIkLctnM"
+   },
+   "source": [
+    "### What you will learn:\n",
+    "\n",
+    "By the end of this lab, you will be able to:\n",
+    "\n",
+    "* Explain why a larger batch size can cause out-of-memory errors.\n",
+    "* Describe the concept of gradient accumulation.\n",
+    "* Implement gradient accumulation in Keras to train with a larger effective batch size."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "OGHgDenJcuJT"
+   },
+   "source": [
+    "### Tasks\n",
+    "\n",
+    "**In this lab, you will**:\n",
+    "* Attempt to finetune Gemma-4B with a batch size of 2 and observe the memory error.\n",
+    "* Reconfigure the optimizer to use gradient accumulation.\n",
+    "* Fine-tune the model successfully by simulating a larger batch size of 8.\n",
+    "\n",
+    " **This lab needs to be run on a GPU. Choose a T4 GPU.** See the section \"How to use Google Colaboratory (Colab)\" below for instructions on how to do this.\n",
+    "\n",
+    " **You also need a Kaggle account** to download the weights of the Gemma 3 model. See the section \"Set up a Kaggle account\" for instructions on how to do this.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "NDWsJUGcf4Ru"
+   },
+   "source": [
+    "## How to use Google Colaboratory (Colab)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "wlNG_jg-39Zj"
+   },
+   "source": [
+    "Google Colaboratory (also known as Google Colab) is a platform that allows you to run Python code in your browser. The code is written in **cells** that are excuted on a remote server.\n",
+    "\n",
+    "To run a cell, hover over a cell and click on the `run` button to its left. The run button is the circle with the triangle (▶). Alternatively, you can also click on a cell and use the keyboard combination Ctrl+Return (or ⌘+Return if you are using a Mac).\n",
+    "\n",
+    "To try this out, run the following cell. This should print today's day of the week below it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "UyTT6C0JhGBs"
+   },
+   "outputs": [],
+   "source": [
+    "from datetime import datetime\n",
+    "print(f\"Today is {datetime.today():%A}.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "pbtgZxrpjm6j"
+   },
+   "source": [
+    "Note that the **order in which you run the cells matters**. When you are working through a lab, make sure to always run all cells in order, otherwise the code might not work. If you take a break while working on a lab, Colab may disconnect you and in that case, you have to execute all cells again before  continuing your work. To make this easier, you can select the cell you are currently working on and then choose _Runtime → Run before_  from the menu above (or use the keyboard combination Ctrl/⌘ + F8). This will re-execute all cells before the current one."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Using Colab with a GPU\n",
+    "\n",
+    "Follow these steps to run the activities in this lab on a GPU:\n",
+    "\n",
+    "1.  In the top menu bar, click on **Runtime**.\n",
+    "2.  Select **Change runtime type** from the dropdown menu.\n",
+    "3.  In the pop-up window under **Hardware accelerator**, select **T4 GPU**.\n",
+    "4.  Click **Save**.\n",
+    "\n",
+    "Your Colab session will now restart with GPU access.\n",
+    "\n",
+    "Note that access to GPUs is limited and at times, you may not be able to run this lab on a GPU. All activities will still work but they will run slower and you will have to wait longer for some of the cells to finish running."
+   ],
+   "metadata": {
+    "id": "kN3yE5jSg9zH"
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Set up a Kaggle account\n"
+   ],
+   "metadata": {
+    "id": "n6-dSJ-o_JT9"
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": "\nTo run this notebook, you will have to sign up for [Kaggle](https://www.kaggle.com), a platform that hosts datasets and models for machine learning. You will also need to sign the agreement for using the Gemma 3 model. This is required so that you can download the weights of the Gemma model for fine-tuning.\n\n### Step 1: Create your Kaggle account\n\n* Go to the Kaggle website: https://www.kaggle.com\n\n* Click the \"Register\" button in the top-right corner.\n\n* You can sign up using your Google account (recommended for easy Colab integration) or by entering an email and password.\n\n* Follow the on-screen prompts to complete your registration and verify your email.\n\n### Step 2: Sign the Gemma 3 model agreement\n\n* Make sure you are logged into your new Kaggle account.\n\n* Go directly to the Gemma 3 model card page: https://www.kaggle.com/models/keras/gemma3/keras/\n\n* You should see a \"Request Access\" button.\n\n* Click the button, read through the license agreement, and if you are happy to, click \"Accept\" to gain access to the model. You must do this before the API will let you download the model.\n\n### Step 3: Generate your Kaggle API token\n\n* From any Kaggle page, click on your profile picture or icon in the top-right corner.\n\n* Select \"Settings\" from the drop-down menu.\n\n* Scroll down to the \"API\" section.\n\n* Click the \"Generate New Token\" button.\n\n* Copy the token value that is displayed.\n\n### Step 4: Set your API token in Colab\n\n* Click the \"key\" icon 🔑 in the left-hand sidebar.\n\n* You will see the \"Secrets\" panel.\n\n* In the Colab Secrets panel, create a new secret:\n\n   * Name: `KAGGLE_API_TOKEN`\n\n   * Value: Paste the token you copied in Step 3.\n\n* Make sure the \"Notebook access\" toggle is switched on.",
+   "metadata": {
+    "id": "9iS70YEC_Hx8"
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "LrxGIe_mc3Uo"
+   },
+   "source": [
+    "## Imports\n",
+    "\n",
+    "In this lab, you will use the Keras package for loading and fine-tuning a Gemma model and the Pandas package, for loading the dataset.\n",
+    "\n",
+    "Run the following cell to import the required packages.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "NrgQ_n_ldZde"
+   },
+   "outputs": [],
+   "source": "%%capture\n# Install the custom package for this course.\n!pip install \"git+https://github.com/google-deepmind/ai-foundations.git@main\"\n\nimport os # For setting system variables.\n\nfrom google.colab import userdata # For using Colab secrets.\n\nos.environ[\"KAGGLE_API_TOKEN\"] = userdata.get(\"KAGGLE_API_TOKEN\")\n\nos.environ[\"KERAS_BACKEND\"] = \"jax\"  # Set the Keras backend to JAX.\n# Disable the command buffer pre-allocation to free up memory.\nos.environ[\"XLA_FLAGS\"] = \"--xla_gpu_enable_command_buffer=\"\nos.environ[\"XLA_PYTHON_CLIENT_MEM_FRACTION\"]=\"0.9\"\n\nimport keras # For defining and training models.\nimport keras_nlp # For loading the Keras implementation of Gemma.\nimport pandas as pd # For loading the dataset.\nfrom textwrap import fill # For formatting long paragraphs.\nfrom ai_foundations import formatting # For formatting the training data.\n\nkeras.utils.set_random_seed(812)  # For Keras layers."
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Load and process data\n",
+    "\n",
+    "As in previous labs, the following cell defines a function `format_question` that formats a prompt. It also loads the Africa Galore QA dataset and processes the individual questions so that the data can be used to fine-tune a model to generate answers for flashcards, as in previous courses."
+   ],
+   "metadata": {
+    "id": "5my4qxRUihwN"
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "-QZLk2s3dxuo"
+   },
+   "outputs": [],
+   "source": [
+    "def format_question(\n",
+    "    question: str,\n",
+    "    sot = \"<start_of_turn>\",\n",
+    "    eot = \"<end_of_turn>\"\n",
+    ") -> str:\n",
+    "    \"\"\"\n",
+    "    Formats a question for prompting the model and adds special delimiters at\n",
+    "    the start and end of the question.\n",
+    "\n",
+    "    Args:\n",
+    "      text: The question to be formatted.\n",
+    "      sot: The token to mark the start of a turn.\n",
+    "      eot: The token to mark the end of a turn.\n",
+    "\n",
+    "    Returns:\n",
+    "      Formatted string of the question.\n",
+    "    \"\"\"\n",
+    "\n",
+    "    formatted_q = f\"{sot}user\\n{question}{eot}\\n\"\n",
+    "\n",
+    "    return formatted_q\n",
+    "\n",
+    "# Load the question-answer dataset.\n",
+    "africa_galore_qa = pd.read_json(\n",
+    "    \"https://storage.googleapis.com/dm-educational/assets/ai_foundations/africa_galore_qa_v2.json\"\n",
+    ")\n",
+    "\n",
+    "questions = []  # List of formatted questions.\n",
+    "answers = []  # List of formatted answers.\n",
+    "\n",
+    "for idx, row in africa_galore_qa.iterrows():\n",
+    "    # Run the format_qa function from the previous lab to format the question\n",
+    "    # and the answer.\n",
+    "    question, answer = formatting.format_qa(row)\n",
+    "    questions.append(question)\n",
+    "    answers.append(answer)\n",
+    "\n",
+    "# Show the first set of input and output.\n",
+    "print(questions[0])\n",
+    "print(fill(answers[0], replace_whitespace=False))\n",
+    "\n",
+    "# Prepare the data dictionary for fine-tuning Gemma.\n",
+    "data = {\n",
+    "    \"prompts\": questions,\n",
+    "    \"responses\": answers\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "t0CZHtCvh5JC"
+   },
+   "source": [
+    "## Coding Activity 1: Fine-tune with a larger batch size\n",
+    "\n",
+    "As you have previously encountered, by loading the data in batches you can:\n",
+    "\n",
+    "* Improve training stability. This is because processing only a single datapoint at a time can introduce more noise when estimating gradients.\n",
+    "\n",
+    "* Improve training efficiency by leveraging the parallel processing ability of GPUs to increase the amount of data being processed at once.\n",
+    "\n",
+    "What happens when you try to increase the batch size for training Gemma-4B?\n",
+    "\n",
+    "------\n",
+    "> 💻 **Your task**:\n",
+    ">\n",
+    "> Run the following four cells to load the model, activate LoRA, set the hyperparameters, define the callback function, and set up the training code.\n",
+    ">\n",
+    "> Then, in the cell that calls the `model.fit()` method, change the `batch_size` value to 4.\n",
+    ">\n",
+    "> Observe what happens when you attempt to run training.\n",
+    "\n",
+    "Note: It may take a few minutes before you see any output.\n",
+    "------"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "gaCHPQyyb68v"
+   },
+   "outputs": [],
+   "source": [
+    "# Load the Gemma3-4B Keras model with bfloat16 precision.\n",
+    "model = keras_nlp.models.Gemma3CausalLM.from_preset(\n",
+    "    preset=\"gemma3_4b_text\", dtype=\"bfloat16\"\n",
+    ")\n",
+    "model.summary()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "kDGMgiI9eNir"
+   },
+   "outputs": [],
+   "source": [
+    "model.backbone.enable_lora(rank=4)\n",
+    "model.summary()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "cs2VVQA0eZaH"
+   },
+   "outputs": [],
+   "source": [
+    "# Set hyperparameters.\n",
+    "optimizer = keras.optimizers.AdamW(\n",
+    "    learning_rate=1e-4,\n",
+    "    weight_decay=0.01,\n",
+    "    beta_1=0.9,\n",
+    "    beta_2=0.95,\n",
+    "    epsilon=1e-6,\n",
+    "    clipnorm=0.5,\n",
+    ")\n",
+    "\n",
+    "# Determine the number of epochs.\n",
+    "num_epochs = 4\n",
+    "\n",
+    "# Set the maximum length.\n",
+    "model.preprocessor.sequence_length = 400\n",
+    "\n",
+    "# Compile the optimizer.\n",
+    "model.compile(\n",
+    "    optimizer=optimizer,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "# Define a list of prompts you want to check after each epoch.\n",
+    "test_prompts = [\n",
+    "    \"What is Kente cloth?\",\n",
+    "    \"What is Kilimanjaro?\",\n",
+    "    \"What is Tokyo?\"\n",
+    "]\n",
+    "\n",
+    "class GenerationMonitor(keras.callbacks.Callback):\n",
+    "    def on_epoch_end(self, epoch, logs=None):\n",
+    "        print(f\"\\n--- Generations after epoch {epoch + 1} ---\")\n",
+    "        for prompt in test_prompts:\n",
+    "            # Format the prompt correctly for the model.\n",
+    "            formatted_prompt = format_question(prompt)\n",
+    "\n",
+    "            # Generate and print the output.\n",
+    "            output = self.model.generate(formatted_prompt, max_length=150)\n",
+    "            print(output)\n",
+    "            print(\"-\" * 20)"
+   ],
+   "metadata": {
+    "id": "lpcH6wAAe5wN"
+   },
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "# Create an instance of the monitoring callback.\n",
+    "generation_callback = GenerationMonitor()\n",
+    "\n",
+    "# Train the model.\n",
+    "history = model.fit(\n",
+    "    data,\n",
+    "    epochs=num_epochs,\n",
+    "    batch_size=..., # Add your code here.\n",
+    "    callbacks=[generation_callback],\n",
+    ")"
+   ],
+   "metadata": {
+    "id": "c-7F17BLe6YC"
+   },
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### What did you observe?\n",
+    "\n",
+    "You should observe a `RESOURCE_EXHAUSTED` error in the output above. This is very similar to the error you observed in the lab where you attempted to load Gemma-4B with 32-bit floating point numbers.\n",
+    "\n",
+    "This is again an out-of-memory error. It means that the GPU ran out of its dedicated memory while trying to execute the training step.\n",
+    "\n",
+    "The key line is at the end:\n",
+    "\n",
+    "`Out of memory while trying to allocate 52428800 bytes.`\n",
+    "\n",
+    "This tells you the GPU needed to allocate over 52 MB of additional memory for this one step, but it did not have enough free space.\n",
+    "\n",
+    "In the context of this lab, this happened because increasing the batch size from 1 to 4 increased the amount of activations that needed to be stored in memory during the forward pass by a factor of 4. This change was enough to exceed the GPU's memory limit."
+   ],
+   "metadata": {
+    "id": "xB9ae9oAlo9X"
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Restart your Colab session\n",
+    "\n",
+    "Sometimes, especially when working with large models, it is best to clear all variables and free up the GPU's memory for the next task. The most reliable way to do this is to restart your session.\n",
+    "\n",
+    "Before continuing with Coding Activity 2, follow these steps to restart your Colab session:\n",
+    "\n",
+    "1. In the top menu bar, click **Runtime**.\n",
+    "\n",
+    "2. Select **Restart session** from the dropdown menu.\n",
+    "\n",
+    "3. In the pop-up window, click **Yes** to confirm.\n",
+    "\n",
+    "Your Colab session will now restart with a fresh environment. Note that this clears all of your variables and imported libraries, so you will need to re-run the imports and any set-up cells again before proceeding. These are copied below for convenience, so you can start running all cells from the **Coding Activity 2** section."
+   ],
+   "metadata": {
+    "id": "JlLivcuy7cWB"
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Imports"
+   ],
+   "metadata": {
+    "id": "p3KzPKPu8rPb"
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "y4oMCR158OWm"
+   },
+   "outputs": [],
+   "source": "%%capture\n# Install the custom package for this course.\n!pip install \"git+https://github.com/google-deepmind/ai-foundations.git@main\"\n\nimport os # For setting system variables.\n\nfrom google.colab import userdata # For using Colab secrets.\n\nos.environ[\"KAGGLE_API_TOKEN\"] = userdata.get(\"KAGGLE_API_TOKEN\")\n\nos.environ[\"KERAS_BACKEND\"] = \"jax\"  # Set the Keras backend to JAX.\n# Disable the command buffer pre-allocation to free up memory.\nos.environ[\"XLA_FLAGS\"] = \"--xla_gpu_enable_command_buffer=\"\nos.environ[\"XLA_PYTHON_CLIENT_MEM_FRACTION\"]=\"0.9\"\n\nimport keras # For defining and training models.\nimport keras_nlp # For loading the Keras implementation of Gemma.\nimport pandas as pd # For loading the dataset.\nfrom textwrap import fill # For formatting long paragraphs.\nfrom ai_foundations import formatting # For formatting the training data.\n\nkeras.utils.set_random_seed(812)  # For Keras layers."
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Data preprocessing"
+   ],
+   "metadata": {
+    "id": "lrCUW6u-8OWm"
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "noai9jtG8OWm"
+   },
+   "outputs": [],
+   "source": [
+    "def format_question(\n",
+    "    question: str,\n",
+    "    sot = \"<start_of_turn>\",\n",
+    "    eot = \"<end_of_turn>\"\n",
+    ") -> str:\n",
+    "    \"\"\"\n",
+    "    Formats a question for prompting the model and adds special delimiters at\n",
+    "    the start and end of the question.\n",
+    "\n",
+    "    Args:\n",
+    "      text: The question to be formatted.\n",
+    "      sot: The token to mark the start of a turn.\n",
+    "      eot: The token to mark the end of a turn.\n",
+    "\n",
+    "    Returns:\n",
+    "      Formatted string of the question.\n",
+    "    \"\"\"\n",
+    "\n",
+    "    formatted_q = f\"{sot}user\\n{question}{eot}\\n\"\n",
+    "\n",
+    "    return formatted_q\n",
+    "\n",
+    "# Load the question-answer dataset.\n",
+    "africa_galore_qa = pd.read_json(\n",
+    "    \"https://storage.googleapis.com/dm-educational/assets/ai_foundations/africa_galore_qa_v2.json\"\n",
+    ")\n",
+    "\n",
+    "questions = []  # List of formatted questions.\n",
+    "answers = []  # List of formatted answers.\n",
+    "\n",
+    "for idx, row in africa_galore_qa.iterrows():\n",
+    "    # Run the format_qa function from the previous lab to format the question\n",
+    "    # and the answer.\n",
+    "    question, answer = formatting.format_qa(row)\n",
+    "    questions.append(question)\n",
+    "    answers.append(answer)\n",
+    "\n",
+    "# Show the first set of input and output.\n",
+    "print(questions[0])\n",
+    "print(fill(answers[0], replace_whitespace=False))\n",
+    "\n",
+    "# Prepare the data dictionary for fine-tuning Gemma.\n",
+    "data = {\n",
+    "    \"prompts\": questions,\n",
+    "    \"responses\": answers\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Coding Activity 2: Fine-tune with gradient accumulation"
+   ],
+   "metadata": {
+    "id": "dbfJm6wlQFID"
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "You have just confirmed that your GPU cannot handle a physical batch size of 4. One remedy to this issue is to simulate a larger batch size using **gradient accumulation**.\n",
+    "\n",
+    "This technique works by performing the forward and backward passes on several smaller batches and accumulating (summing) their gradients. Only after processing a specified number of small batches does the optimizer update the model's weights using the combined gradient. This achieves the same stable learning signal as a large batch, without the high memory cost."
+   ],
+   "metadata": {
+    "id": "ncBp6REZ8bmq"
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Run the following cells to load and process the data again and to load and prepare the model for fine-tuning."
+   ],
+   "metadata": {
+    "id": "K6xPAYrnV4ki"
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "T0EklPvlQFiW"
+   },
+   "outputs": [],
+   "source": [
+    "# Load the Gemma3-4B Keras model with bfloat16 precision.\n",
+    "model = keras_nlp.models.Gemma3CausalLM.from_preset(\n",
+    "    preset=\"gemma3_4b_text\", dtype=\"bfloat16\"\n",
+    ")\n",
+    "model.summary()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "E3wJ-KqKQFiW"
+   },
+   "outputs": [],
+   "source": [
+    "model.backbone.enable_lora(rank=4)\n",
+    "model.summary()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "------\n",
+    "> 💻 **Your task**:\n",
+    ">\n",
+    "> In the following cell, configure the `AdamW` optimizer to use gradient accumulation.\n",
+    ">\n",
+    "> To do this, you need to add the `gradient_accumulation_steps` argument directly to the optimizer. Configure it to simulate a batch size of **8** (i.e., 8 times as large as the physical batch size).\n",
+    ">\n",
+    "> ```\n",
+    "> optimizer = keras.optimizers.AdamW(\n",
+    ">    learning_rate=1e-4,\n",
+    ">    ...,\n",
+    ">    gradient_accumulation_steps=<NUM_STEPS>\n",
+    ">)\n",
+    "> ```\n",
+    ">\n",
+    "------"
+   ],
+   "metadata": {
+    "id": "BeAerBzkdM3E"
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "SrtWS22qQFiW"
+   },
+   "outputs": [],
+   "source": [
+    "# Set hyperparameters.\n",
+    "optimizer = keras.optimizers.AdamW(\n",
+    "    # Multiply the learning rate to match the new effective batch size.\n",
+    "    learning_rate=8e-4,\n",
+    "    weight_decay=0.01,\n",
+    "    beta_1=0.9,\n",
+    "    beta_2=0.95,\n",
+    "    epsilon=1e-6,\n",
+    "    clipnorm=0.5,\n",
+    "    # Add your code here.\n",
+    ")\n",
+    "\n",
+    "# Determine the number of epochs.\n",
+    "num_epochs = 4\n",
+    "\n",
+    "# Set the maximum length.\n",
+    "model.preprocessor.sequence_length = 400\n",
+    "\n",
+    "# Compile the optimizer.\n",
+    "model.compile(\n",
+    "    optimizer=optimizer,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "# Define a list of prompts you want to check after each epoch.\n",
+    "test_prompts = [\n",
+    "    \"What is Kente cloth?\",\n",
+    "    \"What is Kilimanjaro?\",\n",
+    "    \"What is Tokyo?\"\n",
+    "]\n",
+    "\n",
+    "class GenerationMonitor(keras.callbacks.Callback):\n",
+    "    def on_epoch_end(self, epoch, logs=None):\n",
+    "        print(f\"\\n--- Generations after epoch {epoch + 1} ---\")\n",
+    "        for prompt in test_prompts:\n",
+    "            # Format the prompt correctly for the model.\n",
+    "            formatted_prompt = format_question(prompt)\n",
+    "\n",
+    "            # Generate and print the output.\n",
+    "            output = self.model.generate(formatted_prompt, max_length=150)\n",
+    "            print(output)\n",
+    "            print(\"-\" * 20)"
+   ],
+   "metadata": {
+    "id": "WqtCcY4RQFiW"
+   },
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "# Create an instance of the monitoring callback.\n",
+    "generation_callback = GenerationMonitor()\n",
+    "\n",
+    "# Train the model.\n",
+    "history = model.fit(\n",
+    "    data,\n",
+    "    epochs=num_epochs,\n",
+    "    batch_size=1,\n",
+    "    callbacks=[generation_callback],\n",
+    ")"
+   ],
+   "metadata": {
+    "id": "AdkFVT5XQFiY"
+   },
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### What did you observe?\n",
+    "\n",
+    "Across epochs, you likely observed that the generations become steadily more coherent and on-topic. After one epoch, there is still some incoherence. However, notice that the model does not generate any single-token loops like the \"KMnO4\" output from the previous training run in the lab \"Fine-Tune a Model with bfloat16.\" By the end of the second epoch, the outputs are fluent and factual.\n",
+    "\n",
+    "The prior lab's training run used a physical batch size of 1. In comparison, this run with gradient accumulation, resulted in more coherent results more quickly and finished with a lower loss and higher accuracy. This demonstrates that gradient accumulation improves training stability and leads to smoother training dynamics."
+   ],
+   "metadata": {
+    "id": "Ytks-Qfq_FLn"
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Summary\n",
+    "\n",
+    "This lab introduced you to another practical solution for training with limited GPU resources. You explored how you can use a larger effective batch size than your GPU's memory can physically handle. This can be done through **gradient accumulation**. By accumulating gradients over several smaller batches before updating the weights, you can successfully simulate a larger batch size, gaining the benefit of more stable gradients without the high memory cost."
+   ],
+   "metadata": {
+    "id": "IXwi82sWlpJU"
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Solutions\n",
+    "\n",
+    "The following cells provide reference solutions to the coding activities in this notebook. If you really get stuck after trying to solve the activities yourself, you may want to consult these solutions.\n",
+    "\n",
+    "It is recommended that you *only* look at the solutions after you have tried to solve the activities *multiple times*. The best way to learn challenging concepts in computer science and artificial intelligence is to debug your code piece-by-piece until it works, rather than copying existing solutions.\n",
+    "\n",
+    "If you feel stuck, you may want to first try to debug your code. For example, by adding additional print statements to see what your code is doing at every step. This will provide you with a much deeper understanding of the code and the materials. It will also provide you with practice on how to solve challenging coding problems beyond this course.\n",
+    "\n",
+    "To view the solutions for an activity, click on the arrow to the left of the activity name. If you consult the solutions, do not copy and paste them into the cells above. Instead, look at them, and type them manually into the cell. This will help you understand where you went wrong."
+   ],
+   "metadata": {
+    "id": "OChZEs7AZBxn"
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Coding Activity 1"
+   ],
+   "metadata": {
+    "id": "D_rtDcZ9ZIWg"
+   }
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "# Train the model.\n",
+    "history = model.fit(\n",
+    "    data,\n",
+    "    epochs=num_epochs,\n",
+    "    batch_size=4,\n",
+    "    callbacks=[generation_callback],\n",
+    ")"
+   ],
+   "metadata": {
+    "id": "_B8aCZuAZCSs"
+   },
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Coding Activity 2"
+   ],
+   "metadata": {
+    "id": "usZaaLYES2p0"
+   }
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "# Set hyperparameters.\n",
+    "optimizer = keras.optimizers.AdamW(\n",
+    "    learning_rate=8e-4, # Multiply the learning rate to match the new effective batch size.\n",
+    "    weight_decay=0.01,\n",
+    "    beta_1=0.9,\n",
+    "    beta_2=0.95,\n",
+    "    epsilon=1e-6,\n",
+    "    clipnorm=0.5,\n",
+    "    gradient_accumulation_steps=8,\n",
+    ")"
+   ],
+   "metadata": {
+    "id": "pXVE-zpoS30a"
+   },
+   "execution_count": null,
+   "outputs": []
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "collapsed_sections": [
+    "NDWsJUGcf4Ru",
+    "n6-dSJ-o_JT9",
+    "OChZEs7AZBxn",
+    "D_rtDcZ9ZIWg",
+    "usZaaLYES2p0"
+   ],
+   "provenance": [],
+   "gpuType": "T4"
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  },
+  "accelerator": "GPU"
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
 }


### PR DESCRIPTION
## Summary
- Fixes #19: Replace legacy `KAGGLE_USERNAME`/`KAGGLE_KEY` authentication with the current `KAGGLE_API_TOKEN` method in Labs 7.3, 7.5, and 7.6.
- Updated markdown instructions (Steps 3 & 4) to guide students through generating and storing a single API token instead of extracting two values from a `kaggle.json` file.
- Updated code cells to set `KAGGLE_API_TOKEN` environment variable instead of `KAGGLE_USERNAME` and `KAGGLE_KEY`.
- Note: Lab 7.6 has a duplicate imports cell after a session restart section — both instances were updated.

## Test plan
- [ ] Open Lab 7.3 in Colab, verify the "Set up a Kaggle account" instructions are clear and reference the correct Kaggle UI elements
- [ ] Open Lab 7.5 in Colab, verify the same
- [ ] Open Lab 7.6 in Colab, verify both import cells (before and after session restart) use `KAGGLE_API_TOKEN`
- [ ] Set `KAGGLE_API_TOKEN` as a Colab secret and confirm Gemma model downloads successfully