### PR TITLE
Pin etils to a compatible version to fix shared_memory_array import error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "pandas == 2.2.2",
     "plotly == 5.24.1",
     "IPython == 7.34.0",
+    "etils == 1.14.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
## PR description

This PR fixes the `ImportError` reported in #21.

On the T4 server, the environment is using `etils==1.13.0`, which imports `shared_memory_array` from:

```python
from grain._src.python import shared_memory_array
```

However, after `grain` was upgraded to `v0.2.16`(https://github.com/google/grain/commit/d4477d90a8432759c4c7aee7b297e6d66ef8f626), the module path changed from `grain._src.python` to `grain._src.python.ipc`. Because of that change, the old import path no longer works and raises:

```python
ImportError: cannot import name 'shared_memory_array' from 'grain._src.python'
```

`etils v1.14.0`(https://github.com/google/etils/commit/35bf380300fb5d474afc9f5b80f85613a2d9fd53) already includes the compatibility fix, so this PR pins `etils` in `pyproject.toml` to avoid the error.

As an alternative workaround, downgrading `grain` to `v0.2.15` also avoids the issue.

## Alternative workaround

Another possible workaround is downgrading and pin the `grain` to `v0.2.15`.