### PR TITLE
Pin typeguard to a compatible version to fix Unknown error 'check_arg…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "pandas == 2.2.2",
     "plotly == 5.24.1",
     "IPython == 7.34.0",
+    "typeguard==4.4.1",
 ]
 
 [project.urls]


### PR DESCRIPTION
# Summary

Pin typeguard to 4.4.1 to avoid a compatibility issue between kauldron and newer typeguard releases, which causes Gemma inference to fail with check_argument_types() got an unexpected keyword argument 'memo'. This change provides a temporary workaround until the upstream(https://github.com/google-research/kauldron) dependency chain is updated to support the newer typeguard API.

# Tested result
using `!pip install orbax-checkpoint==0.11.21 jax[cuda12]==0.7.2 etils==1.14.0 typeguard==4.4.1` on gdm_lab_1_3_compare_n_gram_models_and_transformer_language_models
```
%%capture
!pip install orbax-checkpoint==0.11.21 jax[cuda12]==0.7.2 etils==1.14.0 typeguard==4.4.1
!pip install "git+https://github.com/google-deepmind/ai-foundations.git@main"

# Packages used.
import os # For setting a variable needed to load the model onto the GPU.
import pandas as pd # For loading the Africa Galore dataset.

# Functions for clearing outputs and formatting.
from IPython.display import clear_output, display, HTML

# Functions for generating texts with a language model, visualizing probability
# distributions, and loading an n-gram model.
from ai_foundations import generation
from ai_foundations import visualizations
from ai_foundations.ngram import model as ngram_model

# Set the full GPU memory usage for JAX.
os.environ["XLA_PYTHON_CLIENT_MEM_FRACTION"] = "1.00"
```

and everything workfine

<img width="725" height="454" alt="image" src="https://github.com/user-attachments/assets/e501847e-037b-44a8-88ee-45fbbd591844" />
