### PR TITLE
fix(deps): pin kauldron < 1.4.0 to fix AbstractPartialLoader removal

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ classifiers = [  # List of https://pypi.org/classifiers/
 ]
 dependencies = [
     "gemma == 3.0.0",
+    "kauldron < 1.4.0",
     "jax == 0.7.2",
     "keras == 3.10.0",
     "numpy == 2.0.2",


### PR DESCRIPTION
kauldron >= 1.4.0 renamed AbstractPartialLoader to InitTransform, which breaks gemma 3.0.0 at import time. This causes an AttributeError when importing ai_foundations.generation. Pinning kauldron < 1.4.0 ensures compatibility with the current gemma version.