### PR TITLE
Fix: use keras_hub in lab 7.5 Coding Activity 1 solution

### DIFF
--- a/course_7/gdm_lab_7_5_fine_tune_a_model_with_bfloat16.ipynb
+++ b/course_7/gdm_lab_7_5_fine_tune_a_model_with_bfloat16.ipynb
@@ -116,6 +116,9 @@
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "kN3yE5jSg9zH"
+      },
       "source": [
         "### Using Colab with a GPU\n",
         "\n",
@@ -129,22 +132,22 @@
         "Your Colab session will now restart with GPU access.\n",
         "\n",
         "Note that access to GPUs is limited and at times, you may not be able to run this lab on a GPU. All activities will still work but they will run slower and you will have to wait longer for some of the cells to finish running."
-      ],
-      "metadata": {
-        "id": "kN3yE5jSg9zH"
-      }
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "## Set up a Kaggle account\n"
-      ],
       "metadata": {
         "id": "n6-dSJ-o_JT9"
-      }
+      },
+      "source": [
+        "## Set up a Kaggle account\n"
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "9iS70YEC_Hx8"
+      },
       "source": [
         "\n",
         "To run this notebook, you will have to sign up for [Kaggle](https://www.kaggle.com), a platform that hosts datasets and models for machine learning. You will also need to sign the agreement for using the Gemma 3 model. This is required so that you can download the weights of the Gemma model for fine-tuning.\n",
@@ -203,10 +206,7 @@
         "      Value: Copy and paste `YOUR_KAGGLE_API_KEY` from your `kaggle.json` file.\n",
         "\n",
         "* For both secrets, make sure the \"Notebook access\" toggle is switched on.\n"
-      ],
-      "metadata": {
-        "id": "9iS70YEC_Hx8"
-      }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -258,21 +258,21 @@
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "### Load and process data"
-      ],
       "metadata": {
         "id": "5my4qxRUihwN"
-      }
+      },
+      "source": [
+        "### Load and process data"
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "As in previous labs, the following cell defines a function `format_question` that formats a prompt. It also loads the Africa Galore QA dataset and processes the individual questions so that the data can be used to fine-tune a model to generate answers for flashcards, as in previous courses."
-      ],
       "metadata": {
         "id": "XngEInKtii-v"
-      }
+      },
+      "source": [
+        "As in previous labs, the following cell defines a function `format_question` that formats a prompt. It also loads the Africa Galore QA dataset and processes the individual questions so that the data can be used to fine-tune a model to generate answers for flashcards, as in previous courses."
+      ]
     },
     {
       "cell_type": "code",
@@ -378,15 +378,20 @@
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "Now that the model has been loaded in with bfloat16, inspect some of the model weights to verify that its parameters are represented as bfloat16 by running the following cell."
-      ],
       "metadata": {
         "id": "e7Ujtedk99Je"
-      }
+      },
+      "source": [
+        "Now that the model has been loaded in with bfloat16, inspect some of the model weights to verify that its parameters are represented as bfloat16 by running the following cell."
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "6v9ZmF2l-GD7"
+      },
+      "outputs": [],
       "source": [
         "# Access the first transformer block.\n",
         "first_transformer_block = model.backbone.get_layer(\"decoder_block_0\")\n",
@@ -398,12 +403,7 @@
         "query_weights = attention_layer.query_dense.kernel\n",
         "\n",
         "print(f\"The model's weight precision is {query_weights.dtype}.\")"
-      ],
-      "metadata": {
-        "id": "6v9ZmF2l-GD7"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -432,25 +432,25 @@
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "## Fine-tune Gemma-4B with bfloat16"
-      ],
       "metadata": {
         "id": "_I32dlOBk73-"
-      }
+      },
+      "source": [
+        "## Fine-tune Gemma-4B with bfloat16"
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "w13gZ5ct-ySr"
+      },
       "source": [
         "Now that LoRA is enabled, you need to configure the training process. This involves setting the hyperparameters that will guide the learning.\n",
         "\n",
         "Training with a low-precision format like bfloat16 often requires more careful hyperparameter selection than standard 32-bit training. As the numbers are less precise, the learning process can be more sensitive, so it is important to use settings that result in a stable training process.\n",
         "\n",
         "The following cell below sets up the AdamW optimizer with a set of values that have been found to work well for stable bfloat16 fine-tuning. Run the following cell to configure your model for training."
-      ],
-      "metadata": {
-        "id": "w13gZ5ct-ySr"
-      }
+      ]
     },
     {
       "cell_type": "code",
@@ -484,6 +484,9 @@
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "ilPyfAtJAeiD"
+      },
       "source": [
         "### Monitor training progress\n",
         "\n",
@@ -498,13 +501,15 @@
         "* \"What is Tokyo?\": Since there is nothing about Tokyo or Japan in the fine-tuning dataset, this checks if the model retains its pre-trained knowledge while learning the new task.\n",
         "\n",
         "Run the following cell to define this callback."
-      ],
-      "metadata": {
-        "id": "ilPyfAtJAeiD"
-      }
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "lpcH6wAAe5wN"
+      },
+      "outputs": [],
       "source": [
         "# Define a list of prompts you want to check after each epoch.\n",
         "test_prompts = [\n",
@@ -524,28 +529,28 @@
         "            output = self.model.generate(formatted_prompt, max_length=150)\n",
         "            print(output)\n",
         "            print(\"-\" * 20)"
-      ],
-      "metadata": {
-        "id": "lpcH6wAAe5wN"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "vu3hD1lzk-uo"
+      },
       "source": [
         "Now run the following cells to fine-tune the model using LoRA and the bfloat16 number format. Notice how this does not lead to an out-of-memory error.\n",
         "\n",
         "Compare the outputs after each epoch. How do they look?\n",
         "\n",
         "The training will take about five minutes per epoch on a T4 GPU. In total, it should take around 20 minutes for four epochs."
-      ],
-      "metadata": {
-        "id": "vu3hD1lzk-uo"
-      }
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "c-7F17BLe6YC"
+      },
+      "outputs": [],
       "source": [
         "# Create an instance of the monitoring callback.\n",
         "generation_callback = GenerationMonitor()\n",
@@ -557,15 +562,13 @@
         "    batch_size=1,\n",
         "    callbacks=[generation_callback],\n",
         ")"
-      ],
-      "metadata": {
-        "id": "c-7F17BLe6YC"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "xB9ae9oAlo9X"
+      },
       "source": [
         "### What did you observe?\n",
         "\n",
@@ -574,24 +577,24 @@
         "The output of the training process also shows how the model learned to respond to the questions in the desired flashcard format after training for a few epochs. Notice the initial instability in Epoch 1. For the \"Kente\" prompt, the model generates a repeated, random token (\"KMnO4\"). For the \"Tokyo\" prompt, the model keeps generating \"Category:\" lists. However, after this, the generations improve dramatically. The model produces increasingly coherent text matching the flashcard format. The final generations in Epoch 4 are high-quality, factually accurate, and stylistically correct. This shows that using bfloat16 does not compromise the quality of the trained model.\n",
         "\n",
         "You have now successfully trained a 4-billion parameter model on a single GPU, a task that was impossible with standard precision. You have also seen that the final generations are high-quality, indicating that bfloat16 did not significantly harm the model's performance on this task."
-      ],
-      "metadata": {
-        "id": "xB9ae9oAlo9X"
-      }
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "IXwi82sWlpJU"
+      },
       "source": [
         "## Summary\n",
         "\n",
         "Loading the model parameters with a lower precision number format like bfloat16 allows you to use and fine-tune bigger models with limited GPU resources. As you observed in this lab, by using bfloat16 representations, you were able to load all parameters of the Gemma-4B into memory and even fine-tune the model on a T4 GPU available through Colab. This resulted in a model that is able to generate high-quality responses thanks to the powerful 4-billion parameter foundation model that served as the basis for fine-tuning."
-      ],
-      "metadata": {
-        "id": "IXwi82sWlpJU"
-      }
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "OChZEs7AZBxn"
+      },
       "source": [
         "## Solutions\n",
         "\n",
@@ -602,42 +605,40 @@
         "If you feel stuck, you may want to first try to debug your code. For example, by adding additional print statements to see what your code is doing at every step. This will provide you with a much deeper understanding of the code and the materials. It will also provide you with practice on how to solve challenging coding problems beyond this course.\n",
         "\n",
         "To view the solutions for an activity, click on the arrow to the left of the activity name. If you consult the solutions, do not copy and paste them into the cells above. Instead, look at them, and type them manually into the cell. This will help you understand where you went wrong.\n"
-      ],
-      "metadata": {
-        "id": "OChZEs7AZBxn"
-      }
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "### Coding Activity 1"
-      ],
       "metadata": {
         "id": "D_rtDcZ9ZIWg"
-      }
+      },
+      "source": [
+        "### Coding Activity 1"
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "model = keras_nlp.models.Gemma3CausalLM.from_preset(\"gemma3_4b_text\", dtype=\"bfloat16\")"
-      ],
+      "execution_count": null,
       "metadata": {
         "id": "_B8aCZuAZCSs"
       },
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "source": [
+        "model = keras_hub.models.Gemma3CausalLM.from_preset(\"gemma3_4b_text\", dtype=\"bfloat16\")"
+      ]
     }
   ],
   "metadata": {
+    "accelerator": "GPU",
     "colab": {
       "collapsed_sections": [
         "NDWsJUGcf4Ru",
         "n6-dSJ-o_JT9",
         "D_rtDcZ9ZIWg"
       ],
-      "provenance": [],
       "gpuType": "T4",
-      "machine_shape": "hm"
+      "machine_shape": "hm",
+      "provenance": []
     },
     "kernelspec": {
       "display_name": "Python 3",
@@ -645,8 +646,7 @@
     },
     "language_info": {
       "name": "python"
-    },
-    "accelerator": "GPU"
+    }
   },
   "nbformat": 4,
   "nbformat_minor": 0


### PR DESCRIPTION
The solution cell for Coding Activity 1 in course_7/gdm_lab_7_5_fine_tune_a_model_with_bfloat16.ipynb references keras_nlp, but the notebook imports keras_hub (and the task instructions use keras_hub). This causes a NameError when running the solution cell. Replaces keras_nlp with keras_hub to match the rest of the notebook.