### PR TITLE
Fix incorrect token count in Lab 2.5 t-SNE description

### DIFF
--- a/course_2/gdm_lab_2_5_experiment_with_embeddings.ipynb
+++ b/course_2/gdm_lab_2_5_experiment_with_embeddings.ipynb
@@ -867,7 +867,7 @@
         "\n",
         "You are then able to use these 2D points to generate a visualization that gives you an intuitive sense of how the words are distributed in the high-dimensional space. Data points close together in the high-dimensional space will appear closer together in 2D using t-SNE.\n",
         "\n",
-        "Run the following cell to generate an t-SNE plot of the 22 tokens that you have been considering in this activity."
+        "Run the following cell to generate an t-SNE plot of the 24 tokens that you have been considering in this activity."
       ]
     },
     {


### PR DESCRIPTION
## Summary

- Update the prose in Lab 2.5's t-SNE introduction to say "24 tokens" instead of "22 tokens", matching what `load_gemma_embeddings` actually returns.

## Problem

The t-SNE section in `course_2/gdm_lab_2_5_experiment_with_embeddings.ipynb` says:

> Run the following cell to generate an t-SNE plot of the 22 tokens that you have been considering in this activity.

But the embedding file referenced in the notebook (`gemma_embeddings.npz`) actually contains **24** token embeddings:

`king, queen, man, woman, apple, banana, yellow, red, rose, orange, cat, dog, computer, mobile, internet, phone, car, bus, good, bad, happy, sad, joy, anger`

Confirmed by running the load cell in Google Colab:

```
The number of tokens are 24.
```

The prose likely lagged behind a previous expansion of the embedding set (22 → 24).

## Fix

Single-line markdown edit — see the diff. No code change.

## Test plan

- [x] Verified `len(labels) == 24` after running the load cell against `gemma_embeddings.npz` in Google Colab
- [x] Verified t-SNE plot renders with all 24 token labels
- [x] No code change — markdown only