### PR TITLE
Fix T4 OOM error visibility and parameter count claim in Lab 5.4

### DIFF
--- a/course_5/gdm_lab_5_4_full_parameter_fine_tuning_of_gemma.ipynb
+++ b/course_5/gdm_lab_5_4_full_parameter_fine_tuning_of_gemma.ipynb
@@ -236,6 +236,9 @@
         "os.environ[\"KAGGLE_KEY\"] = userdata.get(\"KAGGLE_KEY\")\n",
         "\n",
         "os.environ[\"KERAS_BACKEND\"] = \"jax\" # Set the Keras backend to JAX.\n",
+        "# Disable the command buffer pre-allocation to free up memory.\n",
+        "os.environ[\"XLA_FLAGS\"] = \"--xla_gpu_enable_command_buffer=\"\n",
+        "os.environ[\"XLA_PYTHON_CLIENT_ALLOCATOR\"] = \"platform\"\n",
         "\n",
         "import keras # For training the model.\n",
         "import keras_hub # For loading Gemma 3.\n",
@@ -245,8 +248,6 @@
         "# \"Format Text for Turn-Based Dialogue.\"\n",
         "from ai_foundations import formatting\n",
         "\n",
-        "# Avoid memory fragmentation on JAX backend.\n",
-        "os.environ[\"XLA_PYTHON_CLIENT_MEM_FRACTION\"] = \"0.95\"\n",
         "keras.utils.set_random_seed(812) # For making the training reproducible."
       ],
       "metadata": {
@@ -426,7 +427,7 @@
     {
       "cell_type": "markdown",
       "source": [
-        "The Gemma 1B model has approximately 1.3 billion parameters (1B for the main transformer blocks and 300M for the token embeddings). A model of this size typically requires around 4GB of memory, so it fits on a T4 GPU with 15GB of memory. However, a 27B model, that is a model with around 27 billion parameters would require roughly 100 GB of memory (27 $\\times$ ~3.7 GB), which exceeds the capacity of a single T4 GPU multiple times.\n",
+        "The Gemma 1B model has approximately 1 billion parameters in total (around 700M for the main transformer blocks and around 300M for the token embeddings, which are shared between the input and output). A model of this size typically requires around 4GB of memory, so it fits on a T4 GPU with 15GB of memory. However, a 27B model, that is a model with around 27 billion parameters would require roughly 100 GB of memory (27 $\\times$ ~3.7 GB), which exceeds the capacity of a single T4 GPU multiple times.\n",
         "\n"
       ],
       "metadata": {


### PR DESCRIPTION
## Problem

Lab 5.4 (`course_5/gdm_lab_5_4_full_parameter_fine_tuning_of_gemma.ipynb`) has two issues that disrupt the lesson the lab is trying to deliver.

### 1. The OOM error doesn't match what the narrative tells students to expect

The lab text says students "should observe an 'out of memory' (OOM) error" when calling `model.fit(...)`. With the package versions pinned by the project (`keras==3.13.2`, `keras_hub==0.26.0`, `jax==0.7.2`, cuDNN 9.10) the actual error students see is:

```
XlaRuntimeError: INTERNAL: No reference output found!
```

Root cause: setting `XLA_PYTHON_CLIENT_MEM_FRACTION=0.95` makes JAX preallocate 14.25 GiB and never release compilation buffers from model loading — so by the time `.fit()` runs, only ~1.7 GiB is free in the JAX pool. The cuDNN autotuner can't get workspace memory and surfaces an opaque `INTERNAL` error instead of the clean `RESOURCE_EXHAUSTED` the narrative implies.

Same root cause as #29 (which fixes the analogous issue in Labs 7.5 and 7.6).

### 2. The "1.3 billion parameters" narrative claim double-counts the token embedding

The "Understanding Gemma's Memory Footprint" cell says:

> The Gemma 1B model has approximately 1.3 billion parameters (1B for the main transformer blocks and 300M for the token embeddings).

But Keras reports `Total params: 999,885,952` for `gemma3_1b`. The token embedding is implemented as a `ReversibleEmbedding` shared between input and output, so its ~302M parameters are already counted inside the backbone's ~999M. Unique parameter count is ~1B, not 1.3B.

## Fix

### 1. Apply the same allocator pattern as #29

In the install/imports cell:
- Move the JAX env-var settings **before** the `import keras` line
- Replace `XLA_PYTHON_CLIENT_MEM_FRACTION=0.95` with `XLA_PYTHON_CLIENT_ALLOCATOR=platform`
- Add `XLA_FLAGS=--xla_gpu_enable_command_buffer=`

After the fix, the same `model.fit(...)` call produces:

```
XlaRuntimeError: RESOURCE_EXHAUSTED: Failed to allocate request for 12.52GiB
                 (13438550016B) on device ordinal 0
```

The 12.52 GiB matches the predicted Adam optimizer state (m + v + gradient at fp32 for ~1B trainable params), giving students a clear, sized OOM that maps directly onto the lab's stated lesson.

### 2. Correct the parameter count claim

Update the "Understanding Gemma's Memory Footprint" markdown cell from:

> The Gemma 1B model has approximately 1.3 billion parameters (1B for the main transformer blocks and 300M for the token embeddings).

to:

> The Gemma 1B model has approximately 1 billion parameters in total (around 700M for the main transformer blocks and around 300M for the token embeddings, which are shared between the input and output).

## Verification

Tested end-to-end on Colab T4 GPU runtime against live HEAD of `main`:

| | Error |
|---|---|
| Before fix | `XlaRuntimeError: INTERNAL: No reference output found!` (or `INTERNAL: No valid config found!` at lower batch size — both opaque) |
| After fix | `XlaRuntimeError: RESOURCE_EXHAUSTED: Failed to allocate request for 12.52GiB (13438550016B) on device ordinal 0` |

## Related

- #29 — same allocator pattern applied to Labs 7.5 and 7.6 (still open). This PR follows that same template and is independent.