### PR TITLE
Fix incorrect parameter count and remove duplicate cell in Lab 5.5

### DIFF
--- a/course_5/gdm_lab_5_5_implement_lora_for_parameter_efficient_fine_tuning.ipynb
+++ b/course_5/gdm_lab_5_5_implement_lora_for_parameter_efficient_fine_tuning.ipynb
@@ -192,7 +192,7 @@
       "source": [
         "## Recap\n",
         "\n",
-        "In the lab \"Full-Parameter Fine-Tuning\", you fine-tuned a small transformer by continuing to update all of its parameters. You observed that this approach did not work for large models. When you tried to train all the parameters of Gemma-1B in Colab, it ran out of memory.  Even though you could circumvent this problem by buying or renting machines with more powerful GPUs, this is costly. Further, this issue gets worse when you consider bigger models. For example, Gemma-1B with its 1.3 billion parameters is relatively small for a large language model and there exist implementations of Gemma with considerably more parameters, such as Gemma-27B [2]. Full-parameter fine-tuning such a model on a single GPU would be impossible even with the most powerful GPUs available today.\n",
+        "In the lab \"Full-Parameter Fine-Tuning\", you fine-tuned a small transformer by continuing to update all of its parameters. You observed that this approach did not work for large models. When you tried to train all the parameters of Gemma-1B in Colab, it ran out of memory.  Even though you could circumvent this problem by buying or renting machines with more powerful GPUs, this is costly. Further, this issue gets worse when you consider bigger models. For example, Gemma-1B with its 1 billion parameters is relatively small for a large language model and there exist implementations of Gemma with considerably more parameters, such as Gemma-27B [2]. Full-parameter fine-tuning such a model on a single GPU would be impossible even with the most powerful GPUs available today.\n",
         "\n",
         "As mentioned before, LoRA does not directly update the weights of a matrix $W$. Instead, it keeps the pre-trained weights frozen in $W_0$, and encodes any updates to $W$ as the sum of the pre-trained weights $W_0$ and the weight updates $\\Delta W$:\n",
         "\n",
@@ -289,33 +289,6 @@
       ],
       "metadata": {
         "id": "njwg4QzTTcVl"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "# All ones input.\n",
-        "x = jnp.array([1, 1, 1, 1, 1, 1, 1, 1])\n",
-        "y = jnp.matmul(x, delta_W)\n",
-        "\n",
-        "print(f\"Output for ones only: {y}\")\n",
-        "\n",
-        "# High values in inputs that do not matter.\n",
-        "x = jnp.array([100, 100, 1, 1, 1, 1, 1, 1])\n",
-        "y = jnp.matmul(x, delta_W)\n",
-        "\n",
-        "print(f\"Output for high 1st and 2nd input: {y}\")\n",
-        "\n",
-        "# Higher values (7) in the two inputs that reverse the sign.\n",
-        "x = jnp.array([1, 1, 7, 1, 1, 7, 1, 1])\n",
-        "y = jnp.matmul(x, delta_W)\n",
-        "\n",
-        "print(f\"Output with input that reverses the sign: {y}\")"
-      ],
-      "metadata": {
-        "id": "G6lH3el4EBgv"
       },
       "execution_count": null,
       "outputs": []


### PR DESCRIPTION
## Summary

Two minor edits to `course_5/gdm_lab_5_5_implement_lora_for_parameter_efficient_fine_tuning.ipynb`:

1. The Recap markdown describes Gemma 3 1B as having "1.3 billion parameters". The [Gemma 3 Technical Report](https://arxiv.org/abs/2503.19786), Table 1, gives 698M non-embedding + 302M embedding = ~1.0B total for the 1B variant, which matches the `model.summary()` output students see in the previous lab (`Total params: 999,885,952`). Updating the figure to match.
2. The example-inputs code cell — the one that prints `Output for ones only`, `Output for high 1st and 2nd input`, and `Output with input that reverses the sign` — appears twice in a row in the "Intuition behind matrix decomposition" section. The two cells are functionally identical (only whitespace differs: `x,delta_W` vs `x, delta_W`) with no markdown between them. Removing the duplicate.

## Changes

- **Recap markdown:** `1.3 billion parameters` → `1 billion parameters`.
- **Cell removal:** delete the second of the two identical example-inputs cells. The first remains in place, preserving reading order. `delta_W` is defined in the cell immediately above both copies, and the next markdown ("If you add an additional row to A...") moves to a new topic, so no downstream cell depends on the deleted one.

## Verification

Tested on a Colab T4 GPU runtime against `git+https://github.com/google-deepmind/ai-foundations.git@main`:

- All three coding activities pass: `LoraDense.call()` returns shape `(1, 512)` matching the pretrained model; `pretrained_model.summary()` reports 262,656 params; `lora_model.summary()` reports 270,848 total / 8,704 trainable / 262,144 frozen; `feedback.check_loralab_answer(0.0331, num_units=512, rank=8)` returns `Nice! Your answer looks correct.`
- Removing the duplicate cell does not break the run — the surviving cell uses the `delta_W` defined immediately above it, and no later cell references a variable defined in the removed cell.

## Related

- #32 — same parameter count correction in Lab 5.4 (separate PR per the one-notebook-per-PR convention).