### PR TITLE
Fix IndentationError in worked example and stratify reference in Lab 8.2

### DIFF
--- a/course_8/gdm_lab_8_2_classification_part_1.ipynb
+++ b/course_8/gdm_lab_8_2_classification_part_1.ipynb
@@ -641,7 +641,7 @@
         ">      )\n",
         ">      # Split into validation and test sets.\n",
         ">      df_val, df_test = train_test_split(\n",
-        ">          df_val_test, test_size=0.5, random_state=42, stratify=df[\"category\"]\n",
+        ">          df_val_test, test_size=0.5, random_state=42, stratify=df_val_test[\"category\"]\n",
         ">      )\n",
         "> ```\n",
         "> <br>\n",
@@ -879,7 +879,7 @@
       "source": [
         "```python\n",
         "def to_instruction_record(row) -> dict[str, str]:\n",
-        "     \"\"\"Transform a single dataset row into instruction-tuning format.\n",
+        "    \"\"\"Transform a single dataset row into instruction-tuning format.\n",
         "\n",
         "    Args:\n",
         "      row: A single row from a Pandas DataFrame.\n",


### PR DESCRIPTION
Fixes two bugs plus typos in `course_8/gdm_lab_8_2_classification_part_1.ipynb`.

**Activity 4 worked example raises `IndentationError` when copied verbatim.** In the "Worked example: Format the data" cell, the `to_instruction_record` docstring is indented 3 spaces while the function body is indented 4. Copying the template into the implementation cell (as the activity instructs) fails with `IndentationError: unexpected indent`. Re-indenting the docstring to 4 spaces lets the cell run and write the three JSONL splits.

**Activity 3 task box stratifies on the wrong DataFrame.** The alternative stratified-split snippet passes `stratify=df['category']` when splitting `df_val_test`, which raises `ValueError` (inconsistent sample counts). Changed to `stratify=df_val_test['category']`, matching the worked example below it.

**Typos:** `Disccover`, `excuted`, `funcion`, `processs`, `captstone`, and a stray leading space on a code fence.

Ran the worked-example pipeline end-to-end to confirm the fixes.
