### PR TITLE
Fix mislabeled Recall row in evaluation summary and typos in Lab 8.3

### DIFF
--- a/course_8/gdm_lab_8_3_classification_part_2.ipynb
+++ b/course_8/gdm_lab_8_3_classification_part_2.ipynb
@@ -67,7 +67,7 @@
         "\n",
         "* Iterate on the hyperparameter settings and fine-tuning process until you are satisfied with your model's behavior.\n",
         "\n",
-        "The end result of this lab will be a classification model that can catergorize your examples as you specified in your task description.\n",
+        "The end result of this lab will be a classification model that can categorize your examples as you specified in your task description.\n",
         "\n",
         "### What you will use\n",
         "\n",
@@ -257,7 +257,7 @@
         "val_data = val_df.to_dict('records')\n",
         "test_data = test_df.to_dict('records')\n",
         "\n",
-        "# Print the first element in train_data, val_data, test_data for verifcation.\n",
+        "# Print the first element in train_data, val_data, test_data for verification.\n",
         "print(train_data[0])\n",
         "print(val_data[0])\n",
         "print(test_data[0])\n",
@@ -405,7 +405,7 @@
         "id": "Q3tuaHRszSVz"
       },
       "source": [
-        "Before starting fine-tuning, ensure that your training data is formatted correctly for the specific model you plan to use. In the previous notebook,you created JSONL files containing classification examples, which can be reused across different models and fine-tuning methods.\n",
+        "Before starting fine-tuning, ensure that your training data is formatted correctly for the specific model you plan to use. In the previous notebook, you created JSONL files containing classification examples, which can be reused across different models and fine-tuning methods.\n",
         "\n",
         "However, each model has its own formatting requirements. The Gemma models support only two conversational roles, **user** and **model**, but not a **system** role. In other words, prompts and responses are structured as direct exchanges between the user and the model, without a separate system message to provide global instructions or context (such as defining tone, style, or constraints). Higher-capacity LLMs, like Gemini, also use a system role for this purpose, allowing developers to set overall behavior at the start of a conversation. Because Gemma does not support the system role, each training example must explicitly include any necessary context or instruction within the user prompt itself. For more information, see the [Gemma formatting and system instructions document](https://ai.google.dev/gemma/docs/core/prompt-structure/).\n",
         "  \n"
@@ -423,7 +423,7 @@
         "> 1. **Implement conversation formatting**:\n",
         ">    - **Special tokens**: The Gemma model uses `<start_of_turn>` and `<end_of_turn>`.\n",
         ">    - **Role labels**: The Gemma model uses `user` and `model` roles.\n",
-        ">    - **Turn structure**: Adpapt the `format_io_as_turns()` function in the worked example to ensure it matches your conversation format requirements.\n",
+        ">    - **Turn structure**: Adapt the `format_io_as_turns()` function in the worked example to ensure it matches your conversation format requirements.\n",
         ">\n",
         "> 2. **Verify formatted output**:\n",
         ">    - Write code to examine examples to verify:\n",
@@ -468,7 +468,7 @@
         "\n",
         "**Single-task classification**\n",
         "\n",
-        "If you only need **category classification**, a record could look simiarly to the following one:\n",
+        "If you only need **category classification**, a record could look similar to the following one:\n",
         "\n",
         "```json\n",
         "{\n",
@@ -1169,9 +1169,9 @@
         "    Generate predictions for all entries in a dataset and save to CSV.\n",
         "\n",
         "    Args:\n",
-        "      data: Dictionary input and output for each prediction.\n",
+        "      data: List of records with \"input\" and \"output\" fields.\n",
+        "      model: The model used to generate predictions.\n",
         "      output_file: Path to save the predictions CSV.\n",
-        "      instruction: Classification instruction to prepend to each item.\n",
         "\n",
         "    Returns:\n",
         "      DataFrame with all predictions added.\n",
@@ -1330,7 +1330,7 @@
         "# Load and display validation data predictions\n",
         "df_pred_unseen = load_and_display_predictions(\n",
         "    \"predictions_val.csv\",\n",
-        "    \"Test data classication\"\n",
+        "    \"Validation data classification\"\n",
         ")\n",
         "```\n"
       ],
@@ -1445,7 +1445,7 @@
         "\n",
         "In the context of a fine-tuned LLM used for classification, you can compute predictions from the model output strings and then apply these metrics to quantify performance across your dataset. Given this is a text-generation-based classifier rather than a traditional model with fixed output heads, treat label-generation accuracy as the basis for these calculations. For more information on how to calculate and interpret these metrics, take a look at the article [*Classification: Accuracy, recall, precision, and related metrics* crash course](https://developers.google.com/machine-learning/crash-course/classification/accuracy-precision-recall).\n",
         "\n",
-        "These metrics provide a quantitative view but may not be able to capture all aspects of a classifier's behavior using LLMs. Sometimes, the model may also fail to follow the expected format, so your code should handle such cases gracefully. Human review and contextual checks are important complimentary analyses.\n"
+        "These metrics provide a quantitative view but may not be able to capture all aspects of a classifier's behavior using LLMs. Sometimes, the model may also fail to follow the expected format, so your code should handle such cases gracefully. Human review and contextual checks are important complementary analyses.\n"
       ]
     },
     {
@@ -1464,7 +1464,7 @@
         "id": "3q8SVXznzSV4"
       },
       "source": [
-        "The following code demonstrates how to compute quantitative evaluation metrics using the CSV files saved earlier. It parses the `model_output` column to extract the predicted class and compares it with the ground-truth `prompt` column.\n",
+        "The following code demonstrates how to compute quantitative evaluation metrics using the CSV files saved earlier. It parses the `model_output` column to extract the predicted class and compares it with the ground-truth `output` column.\n",
         "\n",
         "The code:\n",
         "1. Defines a reusable `evaluate_predictions` function that extracts predicted labels and calculates metrics.\n",
@@ -1577,7 +1577,7 @@
         "    f\"{results_test['precision']:.2%}{'':<7} \"\n",
         ")\n",
         "print(\n",
-        "    f\"{'Precision':<20} {results_train['recall']:.2%}{'':<7} \"\n",
+        "    f\"{'Recall':<20} {results_train['recall']:.2%}{'':<7} \"\n",
         "    f\"{results_val['recall']:.2%}{'':<7} \"\n",
         "    f\"{results_test['recall']:.2%}{'':<7} \"\n",
         ")\n",
@@ -1618,7 +1618,7 @@
         "\n",
         "- **High training accuracy, lower validation/test accuracy**: This is a common pattern. The model naturally performs better on data it was trained on. A moderate gap is expected and acceptable.\n",
         "\n",
-        "- **A large gap**: This may indicate **overfitting**, where the model learned noise in the training examples rather than learning generalizable patterns. Consider reducing epochs, increasing training data diversity, or applying regularization to prevent\n",
+        "- **A large gap**: This may indicate **overfitting**, where the model learned noise in the training examples rather than learning generalizable patterns. Consider reducing epochs, increasing training data diversity, or applying regularization to prevent overfitting.\n",
         "\n",
         "- **Similar performance on both**: Indicates good generalization. The model has learned underlying patterns rather than overfitting on noise in the training data.\n",
         "\n",
@@ -1653,7 +1653,7 @@
         "\n",
         "If you identified any systematic issues or are otherwise not yet satisfied with the performance of your classifier, think how you may be able to improve your system. You can then go back to individual steps, make changes and repeat the training and evaluation of your model to determine whether the changes are effective.\n",
         "\n",
-        "To do these iterations most systematically, it is best if you do not change too many things at once, so that you learn which components affect your classifier the most. Furthermore, make sure to keep a log of your experiments somehwhere in which you detail the settings of each training run, so that you know at the end what worked best. That way, you can progressivly optimize your machine learning model until you are satisfied with its performance."
+        "To do these iterations most systematically, it is best if you do not change too many things at once, so that you learn which components affect your classifier the most. Furthermore, make sure to keep a log of your experiments somewhere in which you detail the settings of each training run, so that you know at the end what worked best. That way, you can progressively optimize your machine learning model until you are satisfied with its performance."
       ],
       "metadata": {
         "id": "mWhmDA_OIf3c"


### PR DESCRIPTION
Fixes an output bug plus documentation/typo issues in `course_8/gdm_lab_8_3_classification_part_2.ipynb`.

**Evaluation summary table prints "Precision" twice.** In the metrics worked example, the summary block labels its third row `Precision` but prints the recall values:

```
Accuracy             87.50%        83.75%        85.00%
Precision            88.71%        88.24%        86.32%
Precision            87.50%        83.75%        85.00%   <- recall values
```

Changed the second label to `Recall`.

**Documentation fixes.**
- A sentence in "Interpreting the quantitative metrics results" ends mid-thought: "…or applying regularization to prevent" → completed with "overfitting."
- The "Load and display predictions" worked example loads `predictions_val.csv` but titles it "Test data classication" → "Validation data classification".
- The metrics intro says predictions are compared with the ground-truth `prompt` column; the ground-truth column is `output`.
- `generate_all_predictions`'s docstring documented a non-existent `instruction` parameter and omitted `model`; aligned it with the signature.

**Typos:** `catergorize`, `verifcation`, `notebook,you`, `Adpapt`, `simiarly`, `complimentary`, `somehwhere`, `progressivly`.

Ran the worked-example pipeline end-to-end to confirm the fixes.
