### PR TITLE
Fix undefined spot-check helpers and classification copy-paste in Lab 8.6

### DIFF
--- a/course_8/gdm_lab_8_6_summarization_part_2.ipynb
+++ b/course_8/gdm_lab_8_6_summarization_part_2.ipynb
@@ -96,7 +96,7 @@
         "id": "yS737tI1zSVx"
       },
       "source": [
-        "Google Colaboratory (also known as Google Colab) is a platform that allows you to run Python code in your browser. The code is written in cells that are excuted on a remote server.\n",
+        "Google Colaboratory (also known as Google Colab) is a platform that allows you to run Python code in your browser. The code is written in cells that are executed on a remote server.\n",
         "\n",
         "To run a cell, hover over a cell, and click on the `run` button to its left. The run button is the circle with the triangle (▶). Alternatively, you can also click on a cell and use the keyboard combination Ctrl+Return (or ⌘+Return if you are using a Mac).\n",
         "\n",
@@ -248,7 +248,7 @@
         "train_data = train_df.to_dict('records')\n",
         "test_data = test_df.to_dict('records')\n",
         "\n",
-        "# Print the first element in train_data, val_data, test_data for verifcation.\n",
+        "# Print the first element in train_data and test_data for verification.\n",
         "print(train_data[0])\n",
         "print(test_data[0])\n",
         "```"
@@ -395,7 +395,7 @@
         "id": "Q3tuaHRszSVz"
       },
       "source": [
-        "Before starting fine-tuning, ensure that your training data is formatted correctly for the specific model you plan to use. In the previous notebook, you created JSONL files containing classification examples, which can be reused across different models and fine-tuning methods.\n",
+        "Before starting fine-tuning, ensure that your training data is formatted correctly for the specific model you plan to use. In the previous notebook, you created JSONL files containing summarization examples, which can be reused across different models and fine-tuning methods.\n",
         "\n",
         "However, each model has its own formatting requirements. The Gemma models support only two conversational roles, **user** and **model**, but not a **system** role. In other words, prompts and responses are structured as direct exchanges between the user and the model, without a separate system message to provide global instructions or context (such as defining tone, style, or constraints). Higher-capacity LLMs, like Gemini, also use a system role for this purpose, allowing developers to set overall behavior at the start of a conversation. Because Gemma does not support the system role, each training example must explicitly include any necessary context or instruction within the user prompt itself. For more information, see the [Gemma formatting and system instructions document](https://ai.google.dev/gemma/docs/core/prompt-structure/).\n",
         "  \n"
@@ -413,12 +413,12 @@
         "> 1. **Implement conversation formatting**:\n",
         ">    - **Special tokens**: The Gemma model uses `<start_of_turn>` and `<end_of_turn>`.\n",
         ">    - **Role labels**: The Gemma model uses `user` and `model` roles.\n",
-        ">    - **Turn structure**: Adpapt the `format_io_as_turns()` function in the worked example to ensure it matches your conversation format requirements.\n",
+        ">    - **Turn structure**: Adapt the `format_io_as_turns()` function in the worked example to ensure it matches your conversation format requirements.\n",
         ">\n",
         "> 2. **Verify formatted output**:\n",
         ">    - Write code to examine examples to verify:\n",
-        ">      - User turns are properly formatted with the prompt for classification.\n",
-        ">      - Model turns contain the expected classification responses.\n",
+        ">      - User turns are properly formatted with the prompt for summarization.\n",
+        ">      - Model turns contain the expected summarization responses.\n",
         ">      - Special tokens are correctly positioned.\n",
         ">      - The final data dictionary has the required \"prompts\" and \"responses\" keys.\n",
         ">\n",
@@ -1023,7 +1023,7 @@
         "------\n",
         "> 💻 **Your task:**\n",
         ">\n",
-        "> Evaluate your fine-tuned summarization model through manual spot checks and qualitative assessment. You will assess performance on both **seen data** (training examples from `df_train`) and **unseen data** (test examples from `df_test`) to understand how well your model generalizes.\n",
+        "> Evaluate your fine-tuned summarization model through manual spot checks and qualitative assessment. You will assess performance on both **seen data** (training examples in `train_data`) and **unseen data** (test examples in `test_data`) to understand how well your model generalizes.\n",
         ">\n",
         "> 1. **Compare base model vs. fine-tuned model**:\n",
         ">    - The `target_items` list contains 3 items from the training set and 3 from the test set, selected deterministically for consistent comparison.\n",
@@ -1032,17 +1032,15 @@
         ">      - Does the fine-tuned model now produce coherent, concise summaries?\n",
         ">      - How does the output compare to the base model's responses?\n",
         ">\n",
-        "> 2 **Run spot checks using the helper functions**:\n",
-        ">    - `run_spot_check(data, sample_size)` generates summaries for a sample of items.\n",
-        ">    - `extract_summary()` cleans the model output and places results in `generated_summary`.\n",
-        ">    - `display_spot_check(df_spot, title)` displays results in a readable wrapped format.\n",
-        ">    - Run spot checks on both `df_train` (seen) and `df_test` (unseen) data.\n",
+        "> 2. **Run spot checks**:\n",
+        ">    - The `for item in target_items` loop generates a summary for each item with `model.generate()`.\n",
+        ">    - `extract_summary()` cleans each raw model output down to just the generated summary.\n",
+        ">    - Compare the fine-tuned summaries against the base-model outputs you generated earlier on the same `target_items`.\n",
         ">\n",
         "> 3. **Customize evaluation parameters**:\n",
-        ">    - **`sample_size`**: Set number of examples to evaluate (start with 5-10, increase for thorough testing).\n",
-        ">    - **`random_state`**: Change random seed (default: 42) for different sample selection, or remove for true randomness.\n",
-        ">    - **`summarization_instruction`**: Modify to match your specific task and domain (e.g., desired summary length or focus).\n",
-        ">    - **Column names**: Update references like `\"expanded\"`, `\"summary\"`, etc. to match your data structure.\n",
+        ">    - **`n_samples`**: Set how many items are drawn from each of the training and test sets for spot-checking (default: 3).\n",
+        ">    - **`max_length`**: Adjust the generation length cap passed to `model.generate()` if your summaries are longer.\n",
+        ">    - **Column names**: Update references like `\"input\"`, `\"output\"`, etc. to match your data structure.\n",
         ">\n",
         "> 4. **Analyze length ratios**:\n",
         ">    - Run the length ratio analysis code to compare compression behavior between seen and unseen data.\n",
@@ -1230,7 +1228,7 @@
       "outputs": [],
       "execution_count": null,
       "source": [
-        "# Add your code for  here.\n"
+        "# Add your code here.\n"
       ]
     },
     {
@@ -1556,7 +1554,7 @@
         "\n",
         "If you identified any systematic issues or are otherwise not yet satisfied with the performance of your summarization system, think how you may be able to improve your system. You can then go back to individual steps, make changes and repeat the training and evaluation of your model to determine whether the changes are effective.\n",
         "\n",
-        "To do these iterations most systematically, it is best if you do not change too many things at once, so that you learn which components affect your summarization system the most. Furthermore, make sure to keep a log of your experiments somehwhere in which you detail the settings of each training run, so that you know at the end what worked best. That way, you can progressivly optimize your machine learning model until you are satisfied with its performance."
+        "To do these iterations most systematically, it is best if you do not change too many things at once, so that you learn which components affect your summarization system the most. Furthermore, make sure to keep a log of your experiments somewhere in which you detail the settings of each training run, so that you know at the end what worked best. That way, you can progressively optimize your machine learning model until you are satisfied with its performance."
       ],
       "metadata": {
         "id": "mWhmDA_OIf3c"


### PR DESCRIPTION
Fixes a documentation bug plus copy-paste/typo issues in `course_8/gdm_lab_8_6_summarization_part_2.ipynb`.

**Activity 4 references undefined helpers.** The task box tells students to use `run_spot_check(...)`, `display_spot_check(...)`, and a `summarization_instruction` variable. None are defined or imported in the notebook — the worked examples use a plain `for item in target_items` loop with `model.generate()` and `extract_summary()`, so following the bullets verbatim raises `NameError`. Rewrote the bullets to match the code the notebook provides, and pointed the parameter list at the real `n_samples` / `max_length`.

**Stale "classification" wording.** Activity 2 calls the data "classification examples / responses", and the intro and column hints reference `df_train`/`df_test` and `"expanded"`/`"summary"`; this notebook loads `train_data`/`test_data` with `input`/`output`. Updated to match.

**Typos:** `excuted`, `Adpapt`, `somehwhere`, `progressivly`, and a malformed scaffold comment.

Ran the worked-example pipeline end-to-end to confirm the fixes.
